### PR TITLE
Start backfill schedule paused

### DIFF
--- a/features/schedule/backfill/feature.go
+++ b/features/schedule/backfill/feature.go
@@ -63,7 +63,7 @@ func Execute(ctx context.Context, r *harness.Runner) (client.WorkflowRun, error)
 	r.Require.Eventually(func() bool {
 		desc, err := handle.Describe(ctx)
 		r.Require.NoError(err)
-		return desc.Info.NumActions == 4
+		return desc.Info.NumActions == 4 && len(desc.Info.RunningWorkflows) == 0
 	}, 5*time.Second, 1*time.Second)
 	return nil, nil
 }

--- a/features/schedule/backfill/feature.ts
+++ b/features/schedule/backfill/feature.ts
@@ -56,7 +56,7 @@ export const feature = new Feature({
       assert.ok(
         await retry(async function () {
           return handle.describe().then((s) => {
-            return s.info.numActionsTaken == 4;
+            return s.info.numActionsTaken == 4 && s.info.runningActions.length == 0;
           });
         }, 10)
       );

--- a/features/schedule/backfill/feature.ts
+++ b/features/schedule/backfill/feature.ts
@@ -30,6 +30,9 @@ export const feature = new Feature({
         workflowType: workflow,
         taskQueue: runner.options.taskQueue,
       },
+      state: {
+        paused: true,
+      },
     });
 
     try {


### PR DESCRIPTION
Resolves: https://github.com/temporalio/features/issues/210

Schedule was not paused so it could start workflows that are not a result of backfilling. Make sure all the actions are finished before passing the test

```
{"Feature": "schedule/backfill", "error": "failed getting history: after 5s, 1 workflow(s) are still running: schedule-backfill-...
```
