### PR TITLE
Add ability to skip cloud tests

### DIFF
--- a/.github/workflows/all-docker-images.yaml
+++ b/.github/workflows/all-docker-images.yaml
@@ -40,6 +40,10 @@ on:
         description: If set, push the built images to Docker Hub.
         type: boolean
         default: false
+      skip-cloud:
+        description: If set, skip running cloud tests.
+        type: boolean
+        default: false
 
 
 jobs:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -26,6 +26,10 @@ on:
         description: If set, push the built image to Docker Hub.
         type: boolean
         default: false
+      skip-cloud:
+        description: If set, skip running cloud tests.
+        type: boolean
+        default: false
 
 jobs:
   build-image:
@@ -70,7 +74,7 @@ jobs:
 
       - name: Test with Cloud
         # Only supported in non-fork runs
-        if: ${{ github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/features' }}
+        if: ${{ (github.event.pull_request.head.repo.full_name == '' || github.event.pull_request.head.repo.full_name == 'temporalio/features') && !inputs.skip-cloud }}
         run: |
           docker run --rm -i -v /tmp/temporal-certs:/certs ${{ env.FEATURES_BUILT_IMAGE_TAG }} \
           --server $TEMPORAL_CLOUD_ADDRESS \


### PR DESCRIPTION
So we can push images when needed if there are test issues against cloud