### PR TITLE
Add eager_activity/non_remote_activities_worker test for Java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,12 @@ repositories {
 }
 
 dependencies {
-    implementation 'ch.qos.logback:logback-classic:1.2.6'
+    implementation 'ch.qos.logback:logback-classic:1.2.9'
     implementation 'com.google.guava:guava:31.0.1-jre'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.jayway.jsonpath:json-path:2.6.0'
     implementation 'info.picocli:picocli:4.6.2'
-    implementation 'io.temporal:temporal-sdk:1.17.0'
+    implementation 'io.temporal:temporal-sdk:1.18.0-RC1'
     implementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     implementation 'org.reflections:reflections:0.10.2'
 }

--- a/features/eager_activity/non_remote_activities_worker/feature.java
+++ b/features/eager_activity/non_remote_activities_worker/feature.java
@@ -1,0 +1,55 @@
+package eager_activity.non_remote_activities_worker;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.api.enums.v1.TimeoutType;
+import io.temporal.failure.ActivityFailure;
+import io.temporal.failure.TimeoutFailure;
+import io.temporal.sdkfeatures.Feature;
+import io.temporal.sdkfeatures.SimpleWorkflow;
+import io.temporal.worker.WorkerOptions;
+
+import java.time.Duration;
+
+@ActivityInterface
+public interface feature extends Feature, SimpleWorkflow {
+    // Start a worker with activities registered and non-local activities disabled
+    @Override
+    default void workerOptions(WorkerOptions.Builder builder) {
+        builder.setLocalActivityWorkerOnly(true);
+    }
+
+    @ActivityMethod
+    void dummy();
+
+    class Impl implements feature {
+        @Override
+        public void workflow() {
+            // Run a workflow that schedules a single activity with short schedule-to-close
+            // timeout
+            var activities = activities(feature.class, builder -> builder
+                    // Pick a long enough timeout for busy CI but not too long to get feedback
+                    // quickly
+                    .setScheduleToCloseTimeout(Duration.ofSeconds(3)));
+
+            try {
+                activities.dummy();
+                throw new RuntimeException("Expected activity to throw");
+            } catch (ActivityFailure e) {
+                // Catch activity failure in the workflow, check that it is caused by
+                // schedule-to-start timeout
+                if (e.getCause() instanceof TimeoutFailure) {
+                    var timeoutFailure = ((TimeoutFailure) e.getCause());
+                    if (timeoutFailure.getTimeoutType() == TimeoutType.TIMEOUT_TYPE_SCHEDULE_TO_START) {
+                        return;
+                    }
+                }
+                throw e;
+            }
+        }
+
+        @Override
+        public void dummy() {
+        }
+    }
+}

--- a/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
+++ b/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
@@ -11,6 +11,7 @@ public class PreparedFeature {
       continue_as_new.continue_as_same.feature.Impl.class,
       data_converter.binary.feature.Impl.class,
       data_converter.empty.feature.Impl.class,
+      eager_activity.non_remote_activities_worker.feature.Impl.class,
       query.successful_query.feature.Impl.class,
       query.timeout_due_to_no_active_workers.feature.Impl.class,
       query.unexpected_arguments.feature.Impl.class,


### PR DESCRIPTION
Reverting https://github.com/temporalio/features/pull/173, fixing the test check (timeout type)
Related to: https://github.com/temporalio/sdk-java/issues/1504