### PR TITLE
Scrub WorkflowTaskStartedEventAttributes.HistorySizeBytes

### DIFF
--- a/harness/go/history/history.go
+++ b/harness/go/history/history.go
@@ -183,6 +183,7 @@ func scrubRunSpecificScalars(v interface{}) {
 	case *history.WorkflowTaskStartedEventAttributes:
 		v.Identity = ""
 		v.RequestId = ""
+		v.HistorySizeBytes = 0
 	case *history.WorkflowTaskCompletedEventAttributes:
 		v.Identity = ""
 		v.BinaryChecksum = ""


### PR DESCRIPTION
History comparison is failing now that server populates this field: https://github.com/temporalio/temporal/actions/runs/4210199925/jobs/7315310825#step:10:474