### PR TITLE
Loosen version spec on protobuf-compiler

### DIFF
--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -5,7 +5,7 @@ FROM eclipse-temurin:11 as build
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.12.4-1ubuntu7 git=1:2.34.1-1ubuntu1
+      protobuf-compiler=3.12.4* git=1:2.34.1-1ubuntu1
 
 ARG PLATFORM=amd64
 RUN wget -q https://go.dev/dl/go1.19.1.linux-${PLATFORM}.tar.gz \


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Loosen version spec on protobuf-compiler

## Why?
<!-- Tell your future self why have you made these changes -->
Upstream has been messing with the 'ubuntu' version suffixes so depending on the OS version on the runner we get, the version might be 3.12.4-1ubuntu7 or 3.12.4-1ubuntu7.22.04.1. Using a wildcard here will select either version.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Manually running the docker builds

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
