### PR TITLE
Feature test outcome summarization for Go

### DIFF
--- a/cmd/run_go.go
+++ b/cmd/run_go.go
@@ -124,6 +124,7 @@ func (r *Runner) RunGoExternal(ctx context.Context, run *cmd.Run) error {
 		"--namespace", r.config.Namespace,
 		"--client-cert-path", r.config.ClientCertPath,
 		"--client-key-path", r.config.ClientKeyPath,
+		"--summary-uri", r.config.SummaryURI,
 	}, run.ToArgs()...)
 	r.log.Debug("Running Go separately", "Args", runArgs)
 	goCmd := exec.CommandContext(ctx, filepath.Join(r.config.Dir, exe), runArgs...)


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Adds a tcp listener to the features CLI that accepts JSONL data describing feature test results. The JSON objects are expected to have at least three string fields: `name` (test name), `outcome` (PASSED|FAILED|SKIPPED), and `message` (free text). The Go test runner is also updated to emit this data. We use a tcp socket here to support execution under Windows.

## Why?
<!-- Tell your future self why have you made these changes -->

The overall goal here is to avoid trying to run history replays for tests that have been skipped (e.g. due to a lack of server support for the feature as is currently the case for older servers and the update feature).

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
