### PR TITLE
Support more scenarios in the update server check

### DIFF
--- a/features/update/updateutil/serversupportcheck.go
+++ b/features/update/updateutil/serversupportcheck.go
@@ -9,9 +9,22 @@ import (
 )
 
 func CheckServerSupportsUpdate(ctx context.Context, c client.Client) string {
-	handle, _ := c.UpdateWorkflow(ctx, "fake", "also_fake", "__does_not_exist")
-	err := handle.Get(ctx, nil)
+	handle, err := c.UpdateWorkflow(ctx, "fake", "also_fake", "__does_not_exist")
+	// Newer versions of the sdk will return a permission denied error here
 	var denied *serviceerror.PermissionDenied
+	var notFound *serviceerror.NotFound
+	if errors.As(err, &denied) {
+		return "server support for update is disabled; " +
+			"set frontend.enableUpdateWorkflowExecution=true in dynamic config to enable"
+	}
+	// Otherwise we expect a not found error since the workflowID is fake
+	if errors.As(err, &notFound) {
+		return ""
+	}
+	err = handle.Get(ctx, nil)
+
+	// A few early versions of the sdk will return the permission denied error
+	// here so check for that as well
 	if errors.As(err, &denied) {
 		return "server support for update is disabled; " +
 			"set frontend.enableUpdateWorkflowExecution=true in dynamic config to enable"


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Allow a PermissionDenied error either directly returned by the UpdateWorkflow call or returned by the Handle to indicate that the server does not support Update.


## Why?
<!-- Tell your future self why have you made these changes -->
sdk-go will be changing how it returns this error. We want to continue to support either path so that these tests work with older Go SDKs.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Run with older SDKs and the SDK change currently being PR'd with updates enabled and disabled.

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
