### PR TITLE
Wildcard match Typescript OS dependencies

### DIFF
--- a/dockerfiles/ts.Dockerfile
+++ b/dockerfiles/ts.Dockerfile
@@ -8,7 +8,7 @@ FROM node:16 as build
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.6.1.3-2 libprotobuf-dev=3.6.1.3-2
+      protobuf-compiler=3.6.1.3-2* libprotobuf-dev=3.6.1.3-2*
 
 # Get go compiler
 ARG PLATFORM=amd64


### PR DESCRIPTION


<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Wildcard match Typescript OS dependencies

## Why?
<!-- Tell your future self why have you made these changes -->
Debian added semver suffixes to the protobuf-compiler and libprotobuf-dev packages (e.g. 3.6.1.3-2+deb10u1) so we need to be a little bit more flexible in matching dependencies here. Same thing was needed for the Java deps a few months ago.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Local docker build

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
