### PR TITLE
Allow tests to avoid the PanicPolicy override

### DIFF
--- a/harness/go/harness/feature.go
+++ b/harness/go/harness/feature.go
@@ -43,8 +43,15 @@ type Feature struct {
 
 	// Start workflow options that are used by the default executor. Some values
 	// such as task queue and workflow execution timeout, are set by default if
-	// not already set.
+	// not already set. By default the harness sets the WorkflowPanicPolicy to
+	// FailWorkflow - in order to set that one option here you must *also* set the
+	// DisableWorkflowPanicPolicyOverride field to true.
 	StartWorkflowOptions client.StartWorkflowOptions
+
+	// The harness will override the WorkflowPanicPolicy to be FailWorkflow
+	// unless this field is set to true, in which case the WorkflowPanicPolicy
+	// provided via the StartWorkflowOptions field will be honored.
+	DisableWorkflowPanicPolicyOverride bool
 
 	// Default is runner.ExecuteDefault which just runs the first workflow with no
 	// params. If this returns a nil run, no replay or checks are performed. This

--- a/harness/go/harness/runner.go
+++ b/harness/go/harness/runner.go
@@ -91,7 +91,9 @@ func NewRunner(config RunnerConfig, feature *PreparedFeature) (*Runner, error) {
 
 	// Create worker
 	r.CreateTime = time.Now()
-	r.Feature.WorkerOptions.WorkflowPanicPolicy = worker.FailWorkflow
+	if !r.Feature.DisableWorkflowPanicPolicyOverride {
+		r.Feature.WorkerOptions.WorkflowPanicPolicy = worker.FailWorkflow
+	}
 	err = r.StartWorker()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Allow tests to avoid the PanicPolicy override

## Why?
<!-- Tell your future self why have you made these changes -->
This enum doesn't have an "unset" value so the harness cannot tell the difference between a defaulted value and the value intentionally set to the default. The majority of the time we want the FailWorkflow behavior but in edge cases (e.g. tests that intentionally test panic behavior) allow the test to opt out of the override behavior with the DisableWorkflowPanicPolicyOverride flag.


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Feature test for panics during workflow updates coming in subsequent PR

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
