### PR TITLE
Fix incorrect autosetup image name when using just-built server images

### DIFF
--- a/dockerfiles/docker-compose.for-server-image.yaml
+++ b/dockerfiles/docker-compose.for-server-image.yaml
@@ -4,7 +4,7 @@ version: "3.5"
 
 services:
   temporal-server:
-    image: temporalio/auto-setup:latest
+    image: temporalio-autosetup:latest
     environment:
       - CASSANDRA_SEEDS=cassandra
     ports:


### PR DESCRIPTION
We were testing released server image rather than the just-built one when triggering builds from the server repo. I'm fairly sure this worked before, so not sure how this went off, but, :shrug: 