### PR TITLE
Revert "Fix incorrect autosetup image name when using just-built server images"

### DIFF
--- a/dockerfiles/docker-compose.for-server-image.yaml
+++ b/dockerfiles/docker-compose.for-server-image.yaml
@@ -4,7 +4,7 @@ version: "3.5"
 
 services:
   temporal-server:
-    image: temporalio-autosetup:latest
+    image: temporalio/auto-setup:latest
     environment:
       - CASSANDRA_SEEDS=cassandra
     ports:


### PR DESCRIPTION
Reverts temporalio/features#277