### PR TITLE
Add missing "proto3-json-serializer" package to package.json

### DIFF
--- a/cmd/run_python.go
+++ b/cmd/run_python.go
@@ -22,7 +22,7 @@ func (p *Preparer) BuildPythonProgram(ctx context.Context) (sdkbuild.Program, er
 	if version == "" {
 		b, err := os.ReadFile(filepath.Join(p.rootDir, "pyproject.toml"))
 		if err != nil {
-			return nil, fmt.Errorf("failed reading package.json: %w", err)
+			return nil, fmt.Errorf("failed reading pyproject.toml: %w", err)
 		}
 		for _, line := range strings.Split(string(b), "\n") {
 			line = strings.TrimSpace(line)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@temporalio/common": "^1.5.2",
         "@temporalio/worker": "^1.5.2",
         "@temporalio/workflow": "^1.5.2",
-        "commander": "^8.3.0"
+        "commander": "^8.3.0",
+        "proto3-json-serializer": "^1.1.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.0",
@@ -2585,9 +2586,9 @@
       }
     },
     "node_modules/proto3-json-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.0.tgz",
-      "integrity": "sha512-SjXwUWe/vANGs/mJJTbw5++7U67nwsymg7qsoPtw6GiXqw3kUy8ByojrlEdVE2efxAdKreX8WkDafxvYW95ZQg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
+      "integrity": "sha512-AwAuY4g9nxx0u52DnSMkqqgyLHaW/XaPLtaAo3y/ZCfeaQB/g4YDH4kb8Wc/mWzWvu0YjOznVnfn373MVZZrgw==",
       "dependencies": {
         "protobufjs": "^7.0.0"
       },
@@ -5426,9 +5427,9 @@
       "dev": true
     },
     "proto3-json-serializer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.0.tgz",
-      "integrity": "sha512-SjXwUWe/vANGs/mJJTbw5++7U67nwsymg7qsoPtw6GiXqw3kUy8ByojrlEdVE2efxAdKreX8WkDafxvYW95ZQg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-1.1.1.tgz",
+      "integrity": "sha512-AwAuY4g9nxx0u52DnSMkqqgyLHaW/XaPLtaAo3y/ZCfeaQB/g4YDH4kb8Wc/mWzWvu0YjOznVnfn373MVZZrgw==",
       "requires": {
         "protobufjs": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@temporalio/common": "^1.5.2",
     "@temporalio/worker": "^1.5.2",
     "@temporalio/workflow": "^1.5.2",
-    "commander": "^8.3.0"
+    "commander": "^8.3.0",
+    "proto3-json-serializer": "^1.1.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -118,6 +118,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
   "dependencies": {
     ` + packageJSONDepStr + `
     "commander": "^8.3.0",
+	"proto3-json-serializer": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## What was changed

- Added missing "proto3-json-serializer" package to package.json.

## Why

- #286 added an import on that package, which would be transitively satisfied by imports on `@temporalio/*` when running features test in its own repo, but fails when running feature tests from the sdk-typescript repo.