### PR TITLE
Add features that test for update deduplication (#290)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,9 @@ bin
 # Emacs backup files
 *~
 
+# Eclipse config files
+.classpath
+.project
+.settings
+
 /dist/

--- a/features/features.go
+++ b/features/features.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/features/features/telemetry/metrics"
 	update_async_accepted "go.temporal.io/features/features/update/activities"
 	update_activities "go.temporal.io/features/features/update/async_accepted"
+	update_deduplication "go.temporal.io/features/features/update/deduplication"
 	update_intercept "go.temporal.io/features/features/update/intercept"
 	update_non_durable_reject "go.temporal.io/features/features/update/non_durable_reject"
 	update_self "go.temporal.io/features/features/update/self"
@@ -76,6 +77,7 @@ func init() {
 		non_remote_activities_worker.Feature,
 		update_activities.Feature,
 		update_async_accepted.Feature,
+		update_deduplication.Feature,
 		update_intercept.Feature,
 		update_non_durable_reject.Feature,
 		update_self.Feature,

--- a/features/update/deduplication/README.md
+++ b/features/update/deduplication/README.md
@@ -1,0 +1,9 @@
+# Deduplication by update ID
+
+When multiple updates targeting the same workflow use the same update identifier, only one update is performed.
+
+# Detailed spec
+
+- Create a `Count` workflow initialized to zero, and with an update handler that increments the count by one, and returns its value.
+- Update the workflow multiple times with the same `UpdateID`.
+- Verify that the final value of count is one.

--- a/features/update/deduplication/feature.go
+++ b/features/update/deduplication/feature.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	enumspb "go.temporal.io/api/enums/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/features/features/update/updateutil"
 	"go.temporal.io/features/harness/go/harness"
 	"go.temporal.io/sdk/client"
@@ -35,6 +37,9 @@ var Feature = harness.Feature{
 				WorkflowID: run.GetID(),
 				RunID:      run.GetRunID(),
 				UpdateName: incrementCount,
+				WaitPolicy: &updatepb.WaitPolicy{
+					LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+				},
 			},
 		)
 		runner.Require.NoError(err)
@@ -46,6 +51,9 @@ var Feature = harness.Feature{
 				WorkflowID: run.GetID(),
 				RunID:      run.GetRunID(),
 				UpdateName: incrementCount,
+				WaitPolicy: &updatepb.WaitPolicy{
+					LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED,
+				},
 			},
 		)
 		runner.Require.NoError(err)

--- a/features/update/deduplication/feature.go
+++ b/features/update/deduplication/feature.go
@@ -60,6 +60,12 @@ var Feature = harness.Feature{
 		runner.Require.NoError(runner.Client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), shutdownSignal, nil))
 		updateutil.RequireNoUpdateRejectedEvents(ctx, runner)
 
+		nUpdates, err := harness.GetCountCompletedUpdates(ctx, runner.Client, run.GetID())
+		if err != nil {
+			return nil, err
+		}
+		runner.Require.Equal(expectedCount, nUpdates)
+
 		return run, ctx.Err()
 	},
 }

--- a/features/update/deduplication/feature.go
+++ b/features/update/deduplication/feature.go
@@ -1,0 +1,90 @@
+package deduplication
+
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/features/features/update/updateutil"
+	"go.temporal.io/features/harness/go/harness"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+const (
+	reusedUpdateID = "reused_update_id"
+	incrementCount = "incrementCount"
+	shutdownSignal = "shutdown_signal"
+	expectedCount  = 1
+)
+
+var Feature = harness.Feature{
+	Workflows: Count,
+	Execute: func(ctx context.Context, runner *harness.Runner) (client.WorkflowRun, error) {
+		if reason := updateutil.CheckServerSupportsUpdate(ctx, runner.Client); reason != "" {
+			return nil, runner.Skip(reason)
+		}
+		run, err := runner.ExecuteDefault(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		handle1, err := runner.Client.UpdateWorkflowWithOptions(
+			ctx,
+			&client.UpdateWorkflowWithOptionsRequest{
+				UpdateID:   reusedUpdateID,
+				WorkflowID: run.GetID(),
+				RunID:      run.GetRunID(),
+				UpdateName: incrementCount,
+			},
+		)
+		runner.Require.NoError(err)
+
+		handle2, err := runner.Client.UpdateWorkflowWithOptions(
+			ctx,
+			&client.UpdateWorkflowWithOptionsRequest{
+				UpdateID:   reusedUpdateID,
+				WorkflowID: run.GetID(),
+				RunID:      run.GetRunID(),
+				UpdateName: incrementCount,
+			},
+		)
+		runner.Require.NoError(err)
+
+		var result int
+		runner.Require.NoError(handle1.Get(ctx, &result))
+		runner.Require.Equal(expectedCount, result)
+
+		runner.Require.NoError(handle2.Get(ctx, &result))
+		runner.Require.Equal(expectedCount, result)
+
+		runner.Require.NoError(runner.Client.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), shutdownSignal, nil))
+		updateutil.RequireNoUpdateRejectedEvents(ctx, runner)
+
+		return run, ctx.Err()
+	},
+}
+
+func Count(ctx workflow.Context) error {
+	counter := 0
+
+	err := workflow.SetUpdateHandler(
+		ctx,
+		incrementCount,
+		func(ctx workflow.Context) (int, error) {
+			counter += 1
+			// Check that deduplication does not need completion
+			err := workflow.Sleep(ctx, time.Second)
+			if err != nil {
+				return counter, err
+			}
+
+			return counter, nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	_ = workflow.GetSignalChannel(ctx, shutdownSignal).Receive(ctx, nil)
+	return ctx.Err()
+}

--- a/features/update/deduplication/feature.java
+++ b/features/update/deduplication/feature.java
@@ -6,9 +6,9 @@ import io.temporal.sdkfeatures.Feature;
 import io.temporal.sdkfeatures.Run;
 import io.temporal.sdkfeatures.Runner;
 import io.temporal.workflow.*;
-import org.junit.jupiter.api.Assertions;
 import java.time.Duration;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
 
 @WorkflowInterface
 public interface feature extends Feature {
@@ -55,17 +55,17 @@ public interface feature extends Feature {
       var stub = runner.client.newWorkflowStub(feature.class, run.execution.getWorkflowId());
 
       var untypedStub =
-        runner.client.newUntypedWorkflowStub(
-          run.execution.getWorkflowId(),
-          Optional.of(run.execution.getRunId()),
-          Optional.empty());
+          runner.client.newUntypedWorkflowStub(
+              run.execution.getWorkflowId(),
+              Optional.of(run.execution.getRunId()),
+              Optional.empty());
 
       var updateOptions =
-        UpdateOptions.newBuilder(Integer.class)
-        .setUpdateName("incrementCount")
-        .setUpdateId(REUSED_UPDATE_ID)
-        .setFirstExecutionRunId(run.execution.getRunId())
-        .build();
+          UpdateOptions.newBuilder(Integer.class)
+              .setUpdateName("incrementCount")
+              .setUpdateId(REUSED_UPDATE_ID)
+              .setFirstExecutionRunId(run.execution.getRunId())
+              .build();
 
       UpdateHandle<Integer> handle1 = untypedStub.startUpdate(updateOptions);
       UpdateHandle<Integer> handle2 = untypedStub.startUpdate(updateOptions);

--- a/features/update/deduplication/feature.java
+++ b/features/update/deduplication/feature.java
@@ -1,0 +1,80 @@
+package update.deduplication;
+
+import io.temporal.client.UpdateHandle;
+import io.temporal.client.UpdateOptions;
+import io.temporal.sdkfeatures.Feature;
+import io.temporal.sdkfeatures.Run;
+import io.temporal.sdkfeatures.Runner;
+import io.temporal.workflow.*;
+import org.junit.jupiter.api.Assertions;
+import java.time.Duration;
+import java.util.Optional;
+
+@WorkflowInterface
+public interface feature extends Feature {
+  Duration SLEEP_TIMEOUT = Duration.ofSeconds(1);
+  String REUSED_UPDATE_ID = "reused_update_id";
+
+  @UpdateMethod
+  int incrementCount();
+
+  @SignalMethod
+  void finish();
+
+  @WorkflowMethod
+  int workflow();
+
+  class Impl implements feature {
+    private boolean doFinish = false;
+    private int counter = 0;
+
+    @Override
+    public int workflow() {
+      Workflow.await(() -> this.doFinish);
+      return counter;
+    }
+
+    @Override
+    public int incrementCount() {
+      counter += 1;
+      // Check that deduplication does not need completion
+      Workflow.sleep(SLEEP_TIMEOUT);
+      return counter;
+    }
+
+    @Override
+    public void finish() {
+      doFinish = true;
+    }
+
+    @Override
+    public Run execute(Runner runner) throws Exception {
+      runner.skipIfUpdateNotSupported();
+
+      var run = runner.executeSingleParameterlessWorkflow();
+      var stub = runner.client.newWorkflowStub(feature.class, run.execution.getWorkflowId());
+
+      var untypedStub =
+        runner.client.newUntypedWorkflowStub(
+          run.execution.getWorkflowId(),
+          Optional.of(run.execution.getRunId()),
+          Optional.empty());
+
+      var updateOptions =
+        UpdateOptions.newBuilder(Integer.class)
+        .setUpdateName("incrementCount")
+        .setUpdateId(REUSED_UPDATE_ID)
+        .setFirstExecutionRunId(run.execution.getRunId())
+        .build();
+
+      UpdateHandle<Integer> handle1 = untypedStub.startUpdate(updateOptions);
+      UpdateHandle<Integer> handle2 = untypedStub.startUpdate(updateOptions);
+
+      Assertions.assertEquals(1, handle1.getResultAsync().get());
+      Assertions.assertEquals(1, handle2.getResultAsync().get());
+
+      stub.finish();
+      return run;
+    }
+  }
+}

--- a/features/update/deduplication/feature.java
+++ b/features/update/deduplication/feature.java
@@ -47,6 +47,13 @@ public interface feature extends Feature {
       doFinish = true;
     }
 
+    public static long getCountCompletedUpdates(Runner runner, Run run) throws Exception {
+      var history = runner.getWorkflowHistory(run);
+      return history.getEventsList().stream()
+          .filter(e -> e.hasWorkflowExecutionUpdateCompletedEventAttributes())
+          .count();
+    }
+
     @Override
     public Run execute(Runner runner) throws Exception {
       runner.skipIfUpdateNotSupported();
@@ -73,6 +80,7 @@ public interface feature extends Feature {
       Assertions.assertEquals(1, handle1.getResultAsync().get());
       Assertions.assertEquals(1, handle2.getResultAsync().get());
 
+      Assertions.assertEquals(1, getCountCompletedUpdates(runner, run));
       stub.finish();
       return run;
     }

--- a/features/update/deduplication/feature.java
+++ b/features/update/deduplication/feature.java
@@ -2,6 +2,7 @@ package update.deduplication;
 
 import io.temporal.client.UpdateHandle;
 import io.temporal.client.UpdateOptions;
+import io.temporal.client.UpdateWaitPolicy;
 import io.temporal.sdkfeatures.Feature;
 import io.temporal.sdkfeatures.Run;
 import io.temporal.sdkfeatures.Runner;
@@ -71,6 +72,7 @@ public interface feature extends Feature {
           UpdateOptions.newBuilder(Integer.class)
               .setUpdateName("incrementCount")
               .setUpdateId(REUSED_UPDATE_ID)
+              .setWaitPolicy(UpdateWaitPolicy.ACCEPTED)
               .setFirstExecutionRunId(run.execution.getRunId())
               .build();
 

--- a/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
+++ b/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
@@ -26,6 +26,7 @@ public class PreparedFeature {
           signal.external.feature.Impl.class,
           update.activities.feature.Impl.class,
           update.async_accepted.feature.Impl.class,
+          update.deduplication.feature.Impl.class,
           update.intercept.feature.Impl.class,
           update.non_durable_reject.feature.Impl.class,
           update.task_failure.feature.Impl.class,


### PR DESCRIPTION
Test that updates with the same update ID, and targeting the same workflow instance,  are properly deduplicated.

Closes Issue #290 and Jira OSS-1250