### PR TITLE
Require TLS 1.2.

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -326,7 +326,10 @@ func (r *Runner) handleHistory(ctx context.Context, run *cmd.Run, summary Summar
 				if err != nil {
 					return fmt.Errorf("failed to load certs: %s", err)
 				}
-				opts.ConnectionOptions.TLS = &tls.Config{Certificates: []tls.Certificate{cert}}
+				opts.ConnectionOptions.TLS = &tls.Config{
+					MinVersion: tls.VersionTLS12,
+					Certificates: []tls.Certificate{cert},
+				}
 			}
 			var err error
 			if cl, err = client.Dial(opts); err != nil {

--- a/harness/go/harness/util.go
+++ b/harness/go/harness/util.go
@@ -240,7 +240,7 @@ func LoadTLSConfig(clientCertPath, clientKeyPath string) (*tls.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to load certs: %s", err)
 		}
-		return &tls.Config{Certificates: []tls.Certificate{cert}}, nil
+		return &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{cert}}, nil
 	} else if clientKeyPath != "" {
 		return nil, errors.New("got TLS key with no cert")
 	}


### PR DESCRIPTION
## What was changed
Added requirement for TLS 1.2 as the minimum version.

## Why?
We should ensure these feature snippets don't allow things the real SDKs disallow.

## Checklist
How was this tested:
I didn't see instructions in the README, so I'm hoping the github workflows run tests.