### PR TITLE
Replace interpolated context variables with defaults.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
 
@@ -52,7 +52,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, os: ${{ matrix.os }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -41,7 +41,7 @@ jobs:
       REPO_URL: ${{ github.event.pull_request.head.repo.html_url }}
     steps:
       - name: Print build information
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, go sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", go sdk version: ${{ inputs.version }}'
         working-directory: '.'
 
       - name: Download docker artifacts

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, java sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", java sdk version: ${{ inputs.version }}'
         working-directory: '.'
 
       - name: Download docker artifacts

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, python sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", python sdk version: ${{ inputs.version }}'
         working-directory: '.'
 
       - name: Download docker artifacts

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -31,7 +31,7 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: ${{ github.head_ref }}, ref: ${{ github.ref }}, ts version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", ts version: ${{ inputs.version }}'
         working-directory: '.'
 
       - name: Download docker artifacts


### PR DESCRIPTION
## What was changed
Replace interpolated github context variables with default variables used more defensively. 

## Why?
This mitigates an attacker naming a branch a command that could run in our runner's context.

## Checklist

How was this tested:
Looked at the output of the CI job and it was fine, as it has been in https://github.com/temporalio/api-go/pull/115