### PR TITLE
Cleanup features.go

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -1,42 +1,42 @@
 package features
 
 import (
-	"github.com/temporalio/features/features/activity/cancel_try_cancel"
-	"github.com/temporalio/features/features/activity/retry_on_error"
-	"github.com/temporalio/features/features/bugs/go/activity_start_race"
-	"github.com/temporalio/features/features/bugs/go/child_workflow_cancel_panic"
-	activity_on_same_version "github.com/temporalio/features/features/build_id_versioning/activity_and_child_on_correct_version"
-	"github.com/temporalio/features/features/build_id_versioning/continues_as_new_on_correct_version"
-	"github.com/temporalio/features/features/build_id_versioning/only_appropriate_worker_gets_task"
-	"github.com/temporalio/features/features/build_id_versioning/unversioned_worker_gets_unversioned_task"
-	"github.com/temporalio/features/features/build_id_versioning/unversioned_worker_no_task"
-	"github.com/temporalio/features/features/build_id_versioning/versions_added_while_worker_polling"
-	"github.com/temporalio/features/features/child_workflow/result"
-	"github.com/temporalio/features/features/child_workflow/signal"
-	"github.com/temporalio/features/features/continue_as_new/continue_as_same"
-	"github.com/temporalio/features/features/data_converter/binary"
-	"github.com/temporalio/features/features/data_converter/binary_protobuf"
-	"github.com/temporalio/features/features/data_converter/codec"
-	"github.com/temporalio/features/features/data_converter/empty"
-	"github.com/temporalio/features/features/data_converter/failure"
-	"github.com/temporalio/features/features/data_converter/json"
-	"github.com/temporalio/features/features/data_converter/json_protobuf"
-	"github.com/temporalio/features/features/eager_activity/non_remote_activities_worker"
-	"github.com/temporalio/features/features/query/successful_query"
-	"github.com/temporalio/features/features/query/timeout_due_to_no_active_workers"
-	"github.com/temporalio/features/features/query/unexpected_arguments"
-	"github.com/temporalio/features/features/query/unexpected_query_type_name"
-	"github.com/temporalio/features/features/query/unexpected_return_type"
-	"github.com/temporalio/features/features/reset/reset_and_delete"
-	"github.com/temporalio/features/features/schedule/backfill"
-	"github.com/temporalio/features/features/schedule/basic"
-	"github.com/temporalio/features/features/schedule/cron"
-	"github.com/temporalio/features/features/schedule/pause"
-	"github.com/temporalio/features/features/schedule/trigger"
-	"github.com/temporalio/features/features/signal/external"
-	"github.com/temporalio/features/features/telemetry/metrics"
-	update_async_accepted "github.com/temporalio/features/features/update/activities"
-	update_activities "github.com/temporalio/features/features/update/async_accepted"
+	activity_cancel_try_cancel "github.com/temporalio/features/features/activity/cancel_try_cancel"
+	activity_retry_on_error "github.com/temporalio/features/features/activity/retry_on_error"
+	bugs_go_activity_start_race "github.com/temporalio/features/features/bugs/go/activity_start_race"
+	bugs_go_child_workflow_cancel_panic "github.com/temporalio/features/features/bugs/go/child_workflow_cancel_panic"
+	build_id_versioning_activity_and_child_on_correct_version "github.com/temporalio/features/features/build_id_versioning/activity_and_child_on_correct_version"
+	build_id_versioning_continues_as_new_on_correct_version "github.com/temporalio/features/features/build_id_versioning/continues_as_new_on_correct_version"
+	build_id_versioning_only_appropriate_worker_gets_task "github.com/temporalio/features/features/build_id_versioning/only_appropriate_worker_gets_task"
+	build_id_versioning_unversioned_worker_gets_unversioned_task "github.com/temporalio/features/features/build_id_versioning/unversioned_worker_gets_unversioned_task"
+	build_id_versioning_unversioned_worker_no_task "github.com/temporalio/features/features/build_id_versioning/unversioned_worker_no_task"
+	build_id_versioning_versions_added_while_worker_polling "github.com/temporalio/features/features/build_id_versioning/versions_added_while_worker_polling"
+	child_workflow_result "github.com/temporalio/features/features/child_workflow/result"
+	child_workflow_signal "github.com/temporalio/features/features/child_workflow/signal"
+	continue_as_new_continue_as_same "github.com/temporalio/features/features/continue_as_new/continue_as_same"
+	data_converter_binary "github.com/temporalio/features/features/data_converter/binary"
+	data_converter_binary_protobuf "github.com/temporalio/features/features/data_converter/binary_protobuf"
+	data_converter_codec "github.com/temporalio/features/features/data_converter/codec"
+	data_converter_empty "github.com/temporalio/features/features/data_converter/empty"
+	data_converter_failure "github.com/temporalio/features/features/data_converter/failure"
+	data_converter_json "github.com/temporalio/features/features/data_converter/json"
+	data_converter_json_protobuf "github.com/temporalio/features/features/data_converter/json_protobuf"
+	eager_activity_non_remote_activities_worker "github.com/temporalio/features/features/eager_activity/non_remote_activities_worker"
+	query_successful_query "github.com/temporalio/features/features/query/successful_query"
+	query_timeout_due_to_no_active_workers "github.com/temporalio/features/features/query/timeout_due_to_no_active_workers"
+	query_unexpected_arguments "github.com/temporalio/features/features/query/unexpected_arguments"
+	query_unexpected_query_type_name "github.com/temporalio/features/features/query/unexpected_query_type_name"
+	query_unexpected_return_type "github.com/temporalio/features/features/query/unexpected_return_type"
+	reset_reset_and_delete "github.com/temporalio/features/features/reset/reset_and_delete"
+	schedule_backfill "github.com/temporalio/features/features/schedule/backfill"
+	schedule_basic "github.com/temporalio/features/features/schedule/basic"
+	schedule_cron "github.com/temporalio/features/features/schedule/cron"
+	schedule_pause "github.com/temporalio/features/features/schedule/pause"
+	schedule_trigger "github.com/temporalio/features/features/schedule/trigger"
+	signal_external "github.com/temporalio/features/features/signal/external"
+	telemetry_metrics "github.com/temporalio/features/features/telemetry/metrics"
+	update_activities "github.com/temporalio/features/features/update/activities"
+	update_async_accepted "github.com/temporalio/features/features/update/async_accepted"
 	update_basic "github.com/temporalio/features/features/update/basic"
 	update_deduplication "github.com/temporalio/features/features/update/deduplication"
 	update_intercept "github.com/temporalio/features/features/update/intercept"
@@ -45,43 +45,50 @@ import (
 	update_task_failure "github.com/temporalio/features/features/update/task_failure"
 	update_validation_replay "github.com/temporalio/features/features/update/validation_replay"
 	update_worker_restart "github.com/temporalio/features/features/update/worker_restart"
-	"github.com/temporalio/features/harness/go/harness"
+	harness "github.com/temporalio/features/harness/go/harness"
 )
 
 func init() {
 	// Please keep list in alphabetical order by unqualified import package
 	// reference/alias
 	harness.MustRegisterFeatures(
-		activity_start_race.Feature,
-		backfill.Feature,
-		basic.Feature,
-		binary.Feature,
-		binary_protobuf.Feature,
-		cancel_try_cancel.Feature,
-		child_workflow_cancel_panic.Feature,
-		continue_as_same.Feature,
-		codec.Feature,
-		cron.Feature,
-		empty.Feature,
-		external.Feature,
-		json.Feature,
-		json_protobuf.Feature,
-		metrics.Feature,
-		pause.Feature,
-		result.Feature,
-		retry_on_error.Feature,
-		failure.Feature,
-		signal.Feature,
-		successful_query.Feature,
-		timeout_due_to_no_active_workers.Feature,
-		trigger.Feature,
-		unexpected_arguments.Feature,
-		unexpected_query_type_name.Feature,
-		unexpected_return_type.Feature,
-		non_remote_activities_worker.Feature,
-		update_basic.Feature,
+		activity_cancel_try_cancel.Feature,
+		activity_retry_on_error.Feature,
+		bugs_go_activity_start_race.Feature,
+		bugs_go_child_workflow_cancel_panic.Feature,
+		build_id_versioning_activity_and_child_on_correct_version.Feature,
+		build_id_versioning_continues_as_new_on_correct_version.Feature,
+		build_id_versioning_only_appropriate_worker_gets_task.Feature,
+		build_id_versioning_unversioned_worker_gets_unversioned_task.Feature,
+		build_id_versioning_unversioned_worker_no_task.Feature,
+		build_id_versioning_versions_added_while_worker_polling.Feature,
+		child_workflow_result.Feature,
+		child_workflow_signal.Feature,
+		continue_as_new_continue_as_same.Feature,
+		data_converter_binary.Feature,
+		data_converter_binary_protobuf.Feature,
+		data_converter_codec.Feature,
+		data_converter_empty.Feature,
+		data_converter_failure.Feature,
+		data_converter_json.Feature,
+		data_converter_json_protobuf.Feature,
+		eager_activity_non_remote_activities_worker.Feature,
+		query_successful_query.Feature,
+		query_timeout_due_to_no_active_workers.Feature,
+		query_unexpected_arguments.Feature,
+		query_unexpected_query_type_name.Feature,
+		query_unexpected_return_type.Feature,
+		reset_reset_and_delete.Feature,
+		schedule_backfill.Feature,
+		schedule_basic.Feature,
+		schedule_cron.Feature,
+		schedule_pause.Feature,
+		schedule_trigger.Feature,
+		signal_external.Feature,
+		telemetry_metrics.Feature,
 		update_activities.Feature,
 		update_async_accepted.Feature,
+		update_basic.Feature,
 		update_deduplication.Feature,
 		update_intercept.Feature,
 		update_non_durable_reject.Feature,
@@ -89,12 +96,5 @@ func init() {
 		update_task_failure.Feature,
 		update_validation_replay.Feature,
 		update_worker_restart.Feature,
-		only_appropriate_worker_gets_task.Feature,
-		unversioned_worker_no_task.Feature,
-		versions_added_while_worker_polling.Feature,
-		activity_on_same_version.Feature,
-		continues_as_new_on_correct_version.Feature,
-		unversioned_worker_gets_unversioned_task.Feature,
-		reset_and_delete.Feature,
 	)
 }

--- a/features/features.go
+++ b/features/features.go
@@ -49,8 +49,7 @@ import (
 )
 
 func init() {
-	// Please keep list in alphabetical order by unqualified import package
-	// reference/alias
+	// Please keep list in alphabetical order
 	harness.MustRegisterFeatures(
 		activity_cancel_try_cancel.Feature,
 		activity_retry_on_error.Feature,
@@ -65,13 +64,13 @@ func init() {
 		child_workflow_result.Feature,
 		child_workflow_signal.Feature,
 		continue_as_new_continue_as_same.Feature,
-		data_converter_binary.Feature,
 		data_converter_binary_protobuf.Feature,
+		data_converter_binary.Feature,
 		data_converter_codec.Feature,
 		data_converter_empty.Feature,
 		data_converter_failure.Feature,
-		data_converter_json.Feature,
 		data_converter_json_protobuf.Feature,
+		data_converter_json.Feature,
 		eager_activity_non_remote_activities_worker.Feature,
 		query_successful_query.Feature,
 		query_timeout_due_to_no_active_workers.Feature,


### PR DESCRIPTION
### What
- Change `features.go` to use a consistent import alias style for all features.

### Why
- It was no longer making sense to allow imports to use the terminal feature name, since there are now several cases where the same terminal feature name is used in multiple different top-level features.

Incidentally this diff was created by GPT4, using the following prompt:

```
Output a new version of this file with all the imports using the same alias style.

Specifically, what that means is the following. Consider these two lines:

update_async_accepted "github.com/temporalio/features/features/update/activities"
...
update_async_accepted.Feature,

That's the style we are going to use for all imports.
Output a new version of the file doing that, and also ensure the imports are sorted 
alphabetically as the comment requests.
Just output the new file, without any extra text or natural language discussion.
```
