### PR TITLE
Replace temporalite with the CLI dev-server

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -69,7 +69,7 @@ jobs:
           ${{ !inputs.sdk-repo-ref && format('--version {0}', inputs.sdk-version) || '' }} \
           ${{ inputs.semver-latest != 'none' && format('--semver-latest {0}', inputs.semver-latest) || '' }}
 
-      - name: Test with Temporalite
+      - name: Test with Dev Server
         run: docker run --rm -i -v /tmp/temporal-certs:/certs ${{ env.FEATURES_BUILT_IMAGE_TAG }}
 
       - name: Test with Cloud
@@ -92,4 +92,3 @@ jobs:
       - name: Push image to DockerHub
         if: inputs.do-push
         run: go run . push-images
-

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The built image will be tagged with `features:go-1.13.1`
 
 ### External Server and Namespace
 
-By default, a [temporalite](https://github.com/DataDog/temporalite) is dynamically started at runtime to handle all
+By default, a [CLI Dev Server](https://github.com/temporalio/cli/#start-the-server) is dynamically started at runtime to handle all
 feature runs and a namespace is dynamically generated. To not start the embedded server, use `--server` to specify the
 address of a server to use. Similarly, to not use a dynamic namespace (that may not be registered on the external
 server), use `--namespace`.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,9 +20,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/temporalio/features/harness/go/cmd"
+	"github.com/temporalio/features/harness/go/devserver"
 	"github.com/temporalio/features/harness/go/harness"
 	"github.com/temporalio/features/harness/go/history"
-	"github.com/temporalio/features/harness/go/temporalite"
 	"github.com/temporalio/features/sdkbuild"
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/sdk/client"
@@ -195,14 +195,14 @@ func (r *Runner) Run(ctx context.Context, patterns []string) error {
 
 	// If the server is not set, start it ourselves
 	if r.config.Server == "" {
-		server, err := temporalite.Start(temporalite.Options{
+		server, err := devserver.Start(devserver.Options{
 			Log: r.log,
 			// TODO(cretz): Configurable?
 			LogLevel:  "error",
 			Namespace: r.config.Namespace,
 		})
 		if err != nil {
-			return fmt.Errorf("failed starting temporalite: %w", err)
+			return fmt.Errorf("failed starting devserver: %w", err)
 		}
 		defer server.Stop()
 		r.config.Server = server.FrontendHostPort

--- a/harness/go/devserver/freeport.go
+++ b/harness/go/devserver/freeport.go
@@ -1,4 +1,4 @@
-package temporalite
+package devserver
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ func (p *portProvider) GetFreePort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
 	if err != nil {
 		if addr, err = net.ResolveTCPAddr("tcp6", "[::1]:0"); err != nil {
-			panic(fmt.Sprintf("temporalite: failed to get free port: %v", err))
+			panic(fmt.Sprintf("cli: failed to get free port: %v", err))
 		}
 	}
 


### PR DESCRIPTION
## What was changed
Replace uses of temporalite with the official CLI's dev-server

## Why?
Temporalite has been deprecated, and to deprecate gogo/protobuf we need to either update temporalite or the CLI. Since temporalite is deprecated let's just stop using it


## Checklist
1. Closes: N/A
2. How was this tested: I ran the go tests locally: `go run . run --lang go`
3. Any docs updates needed? No
