### PR TITLE
Allow a feature to be specified as a relative path

### DIFF
--- a/cmd/run_feature.go
+++ b/cmd/run_feature.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"strings"
 
 	"github.com/temporalio/features/harness/go/cmd"
 	"golang.org/x/mod/semver"
@@ -39,6 +40,7 @@ func (r *Runner) GlobFeatures(patterns []string) ([]*RunFeature, error) {
 		if len(patterns) > 0 {
 			foundMatch := false
 			for _, pattern := range patterns {
+				pattern = strings.TrimPrefix(pattern, "features/")
 				match, err := filepath.Match(pattern, dir)
 				if !match && err == nil {
 					match, err = filepath.Match(pattern, dir+"/feature."+r.config.Lang)


### PR DESCRIPTION
Previously features were specified as e.g. `signal/errors_in_handler`.

With this change that is still true, but it can also be specified as `features/signal/errors_in_handler`.

This improves CLI ergonomics. We can now:

- Use shell tab completion to select features
- Construct a features command line invocation by editing a previous command that featured a relative feature path
- Construct a features command line invocation using a features relative path copied from e.g. `git` or `ls` output
- Etc

The only downside I'm aware of is that no-one may ever create a top-level feature category named "features", which is a non-problem.