### PR TITLE
Set min Python version to 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 temporalio = "^1.4.0"
 
 [tool.poetry.dev-dependencies]

--- a/sdkbuild/python.go
+++ b/sdkbuild/python.go
@@ -99,7 +99,7 @@ description = "Temporal SDK Python Test"
 authors = ["Temporal Technologies Inc <sdk@temporal.io>"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 temporalio = ` + versionStr + `
 ` + options.DependencyName + ` = { path = "../" }
 


### PR DESCRIPTION
## What was changed

Set minimum Python version to 3.8 because 3.7 is being dropped in the Python SDK