### PR TITLE
Use a dockerhub PAT instead of the password

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -86,11 +86,11 @@ jobs:
           --client-key-path /certs/client.key
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         if: inputs.do-push
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PAT }}
 
       - name: Push image to DockerHub
         if: inputs.do-push


### PR DESCRIPTION
## What was changed
CI was changed to use a dockerhub PAT instead of the account password, which has now been removed.

## Why?
We cannot authenticate to dockerhub otherwise

