### PR TITLE
Use the true image name for auto-setup

### DIFF
--- a/dockerfiles/docker-compose.for-server-image.yaml
+++ b/dockerfiles/docker-compose.for-server-image.yaml
@@ -1,14 +1,14 @@
 # This is meant to be used in conjunction with a docker compose file from the server repo
 # (for dependencies) and a docker image for running server itself.
-version: "3.5"
+version: '3.5'
 
 services:
   temporal-server:
-    image: temporal-autosetup:latest
+    image: temporaliotest/auto-setup:latest
     environment:
       - CASSANDRA_SEEDS=cassandra
     ports:
-      - "7233:7233"
+      - '7233:7233'
     depends_on:
       - cassandra
       - elasticsearch
@@ -19,7 +19,7 @@ services:
     image: temporaliotest/features:go
     environment:
       - WAIT_EXTRA_FOR_NAMESPACE
-    command: ["--server", "temporal-server:7233", "--namespace", "default"]
+    command: ['--server', 'temporal-server:7233', '--namespace', 'default']
     depends_on:
       - temporal-server
     networks:
@@ -29,7 +29,7 @@ services:
     image: temporaliotest/features:py
     environment:
       - WAIT_EXTRA_FOR_NAMESPACE
-    command: ["--server", "temporal-server:7233", "--namespace", "default"]
+    command: ['--server', 'temporal-server:7233', '--namespace', 'default']
     depends_on:
       - temporal-server
     networks:
@@ -39,7 +39,7 @@ services:
     image: temporaliotest/features:ts
     environment:
       - WAIT_EXTRA_FOR_NAMESPACE
-    command: ["--server", "temporal-server:7233", "--namespace", "default"]
+    command: ['--server', 'temporal-server:7233', '--namespace', 'default']
     depends_on:
       - temporal-server
     networks:
@@ -49,7 +49,7 @@ services:
     image: temporaliotest/features:java
     environment:
       - WAIT_EXTRA_FOR_NAMESPACE
-    command: ["--server", "temporal-server:7233", "--namespace", "default"]
+    command: ['--server', 'temporal-server:7233', '--namespace', 'default']
     depends_on:
       - temporal-server
     networks:
@@ -59,7 +59,7 @@ services:
     image: temporaliotest/features:cs
     environment:
       - WAIT_EXTRA_FOR_NAMESPACE
-    command: ["--server", "temporal-server:7233", "--namespace", "default"]
+    command: ['--server', 'temporal-server:7233', '--namespace', 'default']
     depends_on:
       - temporal-server
     networks:


### PR DESCRIPTION
## What was changed
I updated the docker-compose file to use the correct name for `auto-setup`, not the name we happened to use in a particular CI pipeline...

## Why?
This name was custom for a particular CI pipeline and does not match our official naming.
This broke when I updated the CI pipeline to use the correct name

