### PR TITLE
Set deadline on timeout_due_to_no_active_workers/feature.ts and upgrade to TS SDK 1.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
   feature-tests-ts:
     uses: ./.github/workflows/typescript.yaml
     with:
-      version: 1.5.2
+      version: 1.9.0
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -142,7 +142,7 @@ jobs:
     with:
       do-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       go-repo-ref: '77626eee301574bc4cfd756dbf0641c61e9e6907'
-      ts-ver: 'v1.5.2'
+      ts-ver: 'v1.9.0'
       java-ver: 'v1.22.0'
       py-ver: 'v1.4.0'
       cs-ver: 'v0.1.0-beta2'

--- a/features/query/timeout_due_to_no_active_workers/feature.ts
+++ b/features/query/timeout_due_to_no_active_workers/feature.ts
@@ -26,7 +26,7 @@ export const feature = new Feature({
     await runner.workerRunPromise;
     // Make a query, it will time out
     try {
-      await wfHandle.query(query);
+      await runner.client.withDeadline(new Date(Date.now() + 1000), () => wfHandle.query(query));
     } catch (e) {
       assert.ok(e instanceof ServiceError);
       const reAnyd = e as any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,11 @@
       "name": "features",
       "dependencies": {
         "@protobuf-ts/protoc": "^2.8.1",
-        "@temporalio/activity": "^1.5.2",
-        "@temporalio/client": "^1.5.2",
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/worker": "^1.5.2",
-        "@temporalio/workflow": "^1.5.2",
+        "@temporalio/activity": "^1.9.0",
+        "@temporalio/client": "^1.9.0",
+        "@temporalio/common": "^1.9.0",
+        "@temporalio/worker": "^1.9.0",
+        "@temporalio/workflow": "^1.9.0",
         "commander": "^8.3.0",
         "proto3-json-serializer": "^1.1.1"
       },
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.0.tgz",
-      "integrity": "sha512-ySMTXQuMvvswoobvN+0LsaPf7ITO2JVfJmHxQKI4cGehNrrUms+n81BlHEX7Hl/LExji6XE3fnI9U04GSkRruA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -196,15 +196,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
-        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -212,11 +211,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@grpc/proto-loader/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
@@ -343,14 +337,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@protobuf-ts/protoc": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.8.2.tgz",
@@ -414,12 +400,13 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@swc/core": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.23.tgz",
-      "integrity": "sha512-Aa7yw5+7ErOxr+G0J1eU2hkb9nEMSdt1Ye3isdAgg9mrsPuttk+cfLp6nP/Lux/VUnu5k4eOxeTy9UhjJhRAFw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.102.tgz",
+      "integrity": "sha512-OAjNLY/f6QWKSDzaM3bk31A+OYHu6cPa9P/rFIx8X5d24tHXUpRiiq6/PYI6SQRjUPlB72GjsjoEU8F+ALadHg==",
       "hasInstallScript": true,
-      "bin": {
-        "swcx": "run_swcx.js"
+      "dependencies": {
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
       },
       "engines": {
         "node": ">=10"
@@ -429,22 +416,30 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.23",
-        "@swc/core-darwin-x64": "1.3.23",
-        "@swc/core-linux-arm-gnueabihf": "1.3.23",
-        "@swc/core-linux-arm64-gnu": "1.3.23",
-        "@swc/core-linux-arm64-musl": "1.3.23",
-        "@swc/core-linux-x64-gnu": "1.3.23",
-        "@swc/core-linux-x64-musl": "1.3.23",
-        "@swc/core-win32-arm64-msvc": "1.3.23",
-        "@swc/core-win32-ia32-msvc": "1.3.23",
-        "@swc/core-win32-x64-msvc": "1.3.23"
+        "@swc/core-darwin-arm64": "1.3.102",
+        "@swc/core-darwin-x64": "1.3.102",
+        "@swc/core-linux-arm-gnueabihf": "1.3.102",
+        "@swc/core-linux-arm64-gnu": "1.3.102",
+        "@swc/core-linux-arm64-musl": "1.3.102",
+        "@swc/core-linux-x64-gnu": "1.3.102",
+        "@swc/core-linux-x64-musl": "1.3.102",
+        "@swc/core-win32-arm64-msvc": "1.3.102",
+        "@swc/core-win32-ia32-msvc": "1.3.102",
+        "@swc/core-win32-x64-msvc": "1.3.102"
+      },
+      "peerDependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.23.tgz",
-      "integrity": "sha512-IGOEHmE4aBDX7gQWpanI3A0ni47UcvX7rmcy0H8kE6mm/y7mEMWskvNsYhYzJl4GVZgw38v1/lL/A7MRX6g71A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.102.tgz",
+      "integrity": "sha512-CJDxA5Wd2cUMULj3bjx4GEoiYyyiyL8oIOu4Nhrs9X+tlg8DnkCm4nI57RJGP8Mf6BaXPIJkHX8yjcefK2RlDA==",
       "cpu": [
         "arm64"
       ],
@@ -457,9 +452,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.23.tgz",
-      "integrity": "sha512-eQSN+JJqx/5Dk2C5uet2l7HifGsDBorQHD3PAVnge5jxl+rXU/zbzX9Un56+uuUB0QYeS4Dyr8cN7NHuIKGxBA==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.102.tgz",
+      "integrity": "sha512-X5akDkHwk6oAer49oER0qZMjNMkLH3IOZaV1m98uXIasAGyjo5WH1MKPeMLY1sY6V6TrufzwiSwD4ds571ytcg==",
       "cpu": [
         "x64"
       ],
@@ -472,9 +467,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.23.tgz",
-      "integrity": "sha512-zxYvggbw6R/sTNey0qgsigFMY59DYepm1+JNojxOKjbnvxmgyeIa5sPdu/5gLj0TtJOiWvSGrpMPNUIVreUSGA==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.102.tgz",
+      "integrity": "sha512-kJH3XtZP9YQdjq/wYVBeFuiVQl4HaC4WwRrIxAHwe2OyvrwUI43dpW3LpxSggBnxXcVCXYWf36sTnv8S75o2Gw==",
       "cpu": [
         "arm"
       ],
@@ -487,9 +482,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.23.tgz",
-      "integrity": "sha512-l8UWhcNvZ6RzNZBBToMYuKYijF0h7mbw2RuFV5rpCYF/k/Wh85PaDHPQIQ6qjMHJsIBHYXUt0HLAP+fiAfBiDw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.102.tgz",
+      "integrity": "sha512-flQP2WDyCgO24WmKA1wjjTx+xfCmavUete2Kp6yrM+631IHLGnr17eu7rYJ/d4EnDBId/ytMyrnWbTVkaVrpbQ==",
       "cpu": [
         "arm64"
       ],
@@ -502,9 +497,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.23.tgz",
-      "integrity": "sha512-TZDPp1wUE1ynVyY0vwIToyOULKEQ91H49R+p6Iu/2YY+UQQwUamhX0Gp8O85RT+j72/iHyhbQkz7yRg6v+GB5A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.102.tgz",
+      "integrity": "sha512-bQEQSnC44DyoIGLw1+fNXKVGoCHi7eJOHr8BdH0y1ooy9ArskMjwobBFae3GX4T1AfnrTaejyr0FvLYIb0Zkog==",
       "cpu": [
         "arm64"
       ],
@@ -517,9 +512,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.23.tgz",
-      "integrity": "sha512-rKqWnOmUyQfoKZuuXs/S0RNobN+kcUyMtwoCdRdCNqOlk1XZRCMpjGc9Aqn73K3xlZ6JXX6oLrXKn375b2dydw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.102.tgz",
+      "integrity": "sha512-dFvnhpI478svQSxqISMt00MKTDS0e4YtIr+ioZDG/uJ/q+RpcNy3QI2KMm05Fsc8Y0d4krVtvCKWgfUMsJZXAg==",
       "cpu": [
         "x64"
       ],
@@ -532,9 +527,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.23.tgz",
-      "integrity": "sha512-1MK9eocIhuIr/+yUKnTNHpYovMQvfKTJQbU4UMfQLg2qyCGKAvO+jOy5JIGR9x04MWqz9U3EHHS/7Id35ekhFQ==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.102.tgz",
+      "integrity": "sha512-+a0M3CvjeIRNA/jTCzWEDh2V+mhKGvLreHOL7J97oULZy5yg4gf7h8lQX9J8t9QLbf6fsk+0F8bVH1Ie/PbXjA==",
       "cpu": [
         "x64"
       ],
@@ -547,9 +542,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.23.tgz",
-      "integrity": "sha512-3nmdugj0SJIGWeCJBhvPWIfnE2Ax8H2KZsJfcaWmWg0SDh19aAt48Ncyd8WHHBandJmVm2fSjaANSjp+cS2S9A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.102.tgz",
+      "integrity": "sha512-w76JWLjkZNOfkB25nqdWUNCbt0zJ41CnWrJPZ+LxEai3zAnb2YtgB/cCIrwxDebRuMgE9EJXRj7gDDaTEAMOOQ==",
       "cpu": [
         "arm64"
       ],
@@ -562,9 +557,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.23.tgz",
-      "integrity": "sha512-2AlGRhys1BsfLjXyWOd+5J/Ko2kkVQVuy3ZR8OBGy7XI54p0PpepabloYI9irr+4bi9vtyxoc5rS21PmJxB83Q==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.102.tgz",
+      "integrity": "sha512-vlDb09HiGqKwz+2cxDS9T5/461ipUQBplvuhW+cCbzzGuPq8lll2xeyZU0N1E4Sz3MVdSPx1tJREuRvlQjrwNg==",
       "cpu": [
         "ia32"
       ],
@@ -577,9 +572,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.23.tgz",
-      "integrity": "sha512-qYKP8sIM7VVLuDb5BkRBoHy28OHZWrUhPTO7WgpErhVVM9wnzmMi/Jgg8SyfMy6oheBjO0QiwWbXONxBwByjnQ==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.102.tgz",
+      "integrity": "sha512-E/jfSD7sShllxBwwgDPeXp1UxvIqehj/ShSUqq1pjR/IDRXngcRSXKJK92mJkNFY7suH6BcCWwzrxZgkO7sWmw==",
       "cpu": [
         "x64"
       ],
@@ -591,98 +586,136 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
+      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw=="
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw=="
+    },
     "node_modules/@temporalio/activity": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.5.2.tgz",
-      "integrity": "sha512-At25g+m0aMuS00VvH1m4p6yzFFpY+CfJWY1jLifcDcfnwJj+o6EiHxtRaylGufDVtZShDAHB/j8W0a1xFgSrPg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.9.0.tgz",
+      "integrity": "sha512-a9bLEUAM/Y8oInFvmjQPOHnTobp4dX6u7Y61Q0eFtuGQsVb4G51UtXAUtxhgn9lZJv37Tjw+K6yvXYjt4vsSXg==",
       "dependencies": {
-        "@temporalio/common": "^1.5.2",
+        "@temporalio/common": "1.9.0",
         "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.5.2.tgz",
-      "integrity": "sha512-pzu3KPVX+n+YXccoQuUGXlx7EyPf9eadgfwrlezJ+gQx67FlEq9bLJ0xmprfwhANIBtcFs5jcUHKWWPHzrIqqA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.9.0.tgz",
+      "integrity": "sha512-8J2ZJe4xaWpq648657oUfNW/moNqgRL3ARq2oxRWH+g0qBOYKvUhGI7xTJSbuA2+s7sSbRyOX7WBnkT5r9ce5A==",
       "dependencies": {
-        "@grpc/grpc-js": "^1.6.7",
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/proto": "^1.5.2",
+        "@grpc/grpc-js": "~1.7.3",
+        "@temporalio/common": "1.9.0",
+        "@temporalio/proto": "1.9.0",
         "abort-controller": "^3.0.0",
-        "long": "^5.2.0",
-        "uuid": "^8.3.2"
+        "long": "^5.2.3",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.5.2.tgz",
-      "integrity": "sha512-sBh+U48ad8k2lvRxOQCfjtF5BKOE+DhgsC7tcRnT3IbKyJXOfbd9KIjpSWHqZZLP19Ah7C8fkDC0faSBHtBaYQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.9.0.tgz",
+      "integrity": "sha512-x7Rmarsy5uOT91lla0p777CFc+uNX62Vgb0FHOcR2X7o1rFl1BPKY9A1Ew7nt28Po59aNbCbdhLykksq4e3yng==",
       "dependencies": {
-        "@opentelemetry/api": "^1.0.3",
-        "@temporalio/proto": "^1.5.2",
-        "long": "^5.2.0",
-        "ms": "^2.1.3",
-        "proto3-json-serializer": "^1.0.3",
+        "@temporalio/proto": "1.9.0",
+        "long": "^5.2.3",
+        "ms": "^3.0.0-canary.1",
+        "proto3-json-serializer": "^2.0.0"
+      }
+    },
+    "node_modules/@temporalio/common/node_modules/proto3-json-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
+      "integrity": "sha512-FB/YaNrpiPkyQNSNPilpn8qn0KdEfkgmJ9JP93PQyF/U4bAiXY5BiUdDhiDO4S48uSQ6AesklgVlrKiqZPzegw==",
+      "dependencies": {
         "protobufjs": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.5.2.tgz",
-      "integrity": "sha512-aLsWCGWOH1Vi6q8kLdETzfuWBlDPr5FVZeulW5EZBWU6+ElklD50eVEko4V2Lp+3n/tpIS5k52a1oCIZZrm/Jw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.9.0.tgz",
+      "integrity": "sha512-QFsYgKOvp2aGjanEMonY4zp/4MaCbFh8cOuGkFf2yFoANqbeMAUC7zwczaK9XN7m+LhyaQCZOYHgnZePPJIp3g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@temporalio/common": "^1.5.2",
+        "@temporalio/common": "1.9.0",
         "arg": "^5.0.2",
-        "cargo-cp-artifact": "^0.1.6",
-        "which": "^2.0.2"
+        "cargo-cp-artifact": "^0.1.8",
+        "which": "^4.0.0"
+      }
+    },
+    "node_modules/@temporalio/core-bridge/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@temporalio/core-bridge/node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.5.2.tgz",
-      "integrity": "sha512-yi9sktBF7EVM1wfh8IZe0iaz54zXpnfUD7zGsdWc7MyXZfl0Ub9Qrx7CxPVJSk+qbvQAx/2OpRzaFgXnyIkhEA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.9.0.tgz",
+      "integrity": "sha512-jfSo/NSEjBXvCwl55A+e7zuJ90ZbAcvU16+4/bLCL6H/8JTDvafVimPcvYi6UQwJZcQMUsKegu8q36HWw/jfgQ==",
       "dependencies": {
-        "long": "^5.2.0",
-        "protobufjs": "^7.0.0"
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.5"
       }
     },
     "node_modules/@temporalio/worker": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.5.2.tgz",
-      "integrity": "sha512-t+3uM3b1FOOciJFfEl20h6s51xuYOLOaQv0qAkDMqCJNN+ZTCsYdOpXBrYok/3wDLqAc9acTZczoFvBh7sF6HA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.9.0.tgz",
+      "integrity": "sha512-ekrmJ/rpM+ErBe7jCBZ1FSf0iAThlMgZ5ez/B02Coy+L7HPVG3MH2hiYi1t6SPcl8zviZbb7vIGTaV0SnWwQYg==",
       "dependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@swc/core": "^1.2.204",
-        "@temporalio/activity": "^1.5.2",
-        "@temporalio/client": "^1.5.2",
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/core-bridge": "^1.5.2",
-        "@temporalio/proto": "^1.5.2",
-        "@temporalio/workflow": "^1.5.2",
+        "@swc/core": "^1.3.102",
+        "@temporalio/activity": "1.9.0",
+        "@temporalio/client": "1.9.0",
+        "@temporalio/common": "1.9.0",
+        "@temporalio/core-bridge": "1.9.0",
+        "@temporalio/proto": "1.9.0",
+        "@temporalio/workflow": "1.9.0",
         "abort-controller": "^3.0.0",
-        "cargo-cp-artifact": "^0.1.6",
-        "heap-js": "^2.2.0",
-        "memfs": "^3.4.6",
-        "ms": "^2.1.3",
-        "rxjs": "^7.5.5",
-        "semver": "^7.3.7",
+        "heap-js": "^2.3.0",
+        "memfs": "^4.6.0",
+        "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
-        "source-map-loader": "^4.0.0",
+        "source-map-loader": "^4.0.2",
         "swc-loader": "^0.2.3",
-        "terser": "^5.14.2",
-        "unionfs": "^4.4.0",
-        "webpack": "^5.73.0"
+        "unionfs": "^4.5.1",
+        "webpack": "^5.89.0"
+      },
+      "engines": {
+        "node": ">= 14.18.0"
       }
     },
     "node_modules/@temporalio/workflow": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.5.2.tgz",
-      "integrity": "sha512-MhGV+vdq+3kdsTBr77G3IGoNoJr9Q5xbhXD9LDuKgD+gBgoDZv09QX4n0AQvMh5Kgks36fV/E7ZIYVgfEKsNRA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.9.0.tgz",
+      "integrity": "sha512-0/9b8bUbtVdvuV9t7BQ7Ki/SVi9y2HnymO70SaT05x2t2aXS8BuW7q73vwIPoKazFdvNK7LA1nNcZ3Kgz9iz8w==",
       "dependencies": {
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/proto": "^1.5.2"
+        "@temporalio/common": "1.9.0",
+        "@temporalio/proto": "1.9.0"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -742,11 +775,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "18.11.17",
@@ -1166,11 +1194,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -1383,9 +1406,9 @@
       ]
     },
     "node_modules/cargo-cp-artifact": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.7.tgz",
-      "integrity": "sha512-pxEV9p1on8vu3BOKstVisF9TwMyGKCBRvzaVpQHuU2sLULCKrn3MJWx/4XlNzmG6xNCTPf78DJ7WCGgr2mOzjg==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.8.tgz",
+      "integrity": "sha512-3j4DaoTrsCD1MRkTF2Soacii0Nx7UHCce0EwUf4fHnggwiE4fbmF2AbnfzayR36DF8KGadfh7M/Yfy625kgPlA==",
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
       }
@@ -1415,13 +1438,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -1894,6 +1920,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "peer": true
+    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -1974,9 +2006,9 @@
       "dev": true
     },
     "node_modules/fs-monkey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
-      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2102,11 +2134,19 @@
       }
     },
     "node_modules/heap-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.2.0.tgz",
-      "integrity": "sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.3.0.tgz",
+      "integrity": "sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "engines": {
+        "node": ">=10.18"
       }
     },
     "node_modules/iconv-lite": {
@@ -2223,7 +2263,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -2275,6 +2316,36 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-joy": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
+      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "dependencies": {
+        "arg": "^5.0.2",
+        "hyperdyperid": "^1.2.0"
+      },
+      "bin": {
+        "jj": "bin/jj.js",
+        "json-pack": "bin/json-pack.js",
+        "json-pack-test": "bin/json-pack-test.js",
+        "json-patch": "bin/json-patch.js",
+        "json-patch-test": "bin/json-patch-test.js",
+        "json-pointer": "bin/json-pointer.js",
+        "json-pointer-test": "bin/json-pointer-test.js",
+        "json-unpack": "bin/json-unpack.js"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "quill-delta": "^5",
+        "rxjs": "7",
+        "tslib": "2"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -2331,6 +2402,18 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "peer": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2344,14 +2427,15 @@
       "dev": true
     },
     "node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2366,14 +2450,22 @@
       "dev": true
     },
     "node_modules/memfs": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
-      "integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.6.0.tgz",
+      "integrity": "sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==",
       "dependencies": {
-        "fs-monkey": "^1.0.3"
+        "json-joy": "^9.2.0",
+        "thingies": "^1.11.1"
       },
       "engines": {
         "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/merge-stream": {
@@ -2444,9 +2536,12 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2597,9 +2692,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2646,6 +2741,20 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "peer": true,
+      "dependencies": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -2755,9 +2864,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -2807,6 +2916,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2889,11 +2999,10 @@
       }
     },
     "node_modules/source-map-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
-      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
+      "integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
       "dependencies": {
-        "abab": "^2.0.6",
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
       },
@@ -3115,6 +3224,17 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/thingies": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.15.0.tgz",
+      "integrity": "sha512-ZSJlvEpD8QllYim0VSGlbAoob/iPrTWNlV/m8ltizMvMmzzU2gVJvHfH9ijLstyciWF70ZiQXqz+BCXWJq+ZQw==",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3264,9 +3384,9 @@
       }
     },
     "node_modules/unionfs": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.4.0.tgz",
-      "integrity": "sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.5.1.tgz",
+      "integrity": "sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==",
       "dependencies": {
         "fs-monkey": "^1.0.0"
       }
@@ -3305,9 +3425,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -3337,9 +3461,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -3413,6 +3537,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3465,31 +3590,32 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -3634,31 +3760,23 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.0.tgz",
-      "integrity": "sha512-ySMTXQuMvvswoobvN+0LsaPf7ITO2JVfJmHxQKI4cGehNrrUms+n81BlHEX7Hl/LExji6XE3fnI9U04GSkRruA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
+      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.4.tgz",
-      "integrity": "sha512-MnWjkGwqQ3W8fx94/c1CwqLsNmHHv2t0CFn+9++6+cDphC1lolpg9M2OU0iebIjK//pBNX9e94ho+gjx6vz39w==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "requires": {
-        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      },
-      "dependencies": {
-        "long": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-          "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-        }
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
       }
     },
     "@humanwhocodes/config-array": {
@@ -3765,11 +3883,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@opentelemetry/api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
-    },
     "@protobuf-ts/protoc": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.8.2.tgz",
@@ -3830,173 +3943,202 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@swc/core": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.23.tgz",
-      "integrity": "sha512-Aa7yw5+7ErOxr+G0J1eU2hkb9nEMSdt1Ye3isdAgg9mrsPuttk+cfLp6nP/Lux/VUnu5k4eOxeTy9UhjJhRAFw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.102.tgz",
+      "integrity": "sha512-OAjNLY/f6QWKSDzaM3bk31A+OYHu6cPa9P/rFIx8X5d24tHXUpRiiq6/PYI6SQRjUPlB72GjsjoEU8F+ALadHg==",
       "requires": {
-        "@swc/core-darwin-arm64": "1.3.23",
-        "@swc/core-darwin-x64": "1.3.23",
-        "@swc/core-linux-arm-gnueabihf": "1.3.23",
-        "@swc/core-linux-arm64-gnu": "1.3.23",
-        "@swc/core-linux-arm64-musl": "1.3.23",
-        "@swc/core-linux-x64-gnu": "1.3.23",
-        "@swc/core-linux-x64-musl": "1.3.23",
-        "@swc/core-win32-arm64-msvc": "1.3.23",
-        "@swc/core-win32-ia32-msvc": "1.3.23",
-        "@swc/core-win32-x64-msvc": "1.3.23"
+        "@swc/core-darwin-arm64": "1.3.102",
+        "@swc/core-darwin-x64": "1.3.102",
+        "@swc/core-linux-arm-gnueabihf": "1.3.102",
+        "@swc/core-linux-arm64-gnu": "1.3.102",
+        "@swc/core-linux-arm64-musl": "1.3.102",
+        "@swc/core-linux-x64-gnu": "1.3.102",
+        "@swc/core-linux-x64-musl": "1.3.102",
+        "@swc/core-win32-arm64-msvc": "1.3.102",
+        "@swc/core-win32-ia32-msvc": "1.3.102",
+        "@swc/core-win32-x64-msvc": "1.3.102",
+        "@swc/counter": "^0.1.1",
+        "@swc/types": "^0.1.5"
       }
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.23.tgz",
-      "integrity": "sha512-IGOEHmE4aBDX7gQWpanI3A0ni47UcvX7rmcy0H8kE6mm/y7mEMWskvNsYhYzJl4GVZgw38v1/lL/A7MRX6g71A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.102.tgz",
+      "integrity": "sha512-CJDxA5Wd2cUMULj3bjx4GEoiYyyiyL8oIOu4Nhrs9X+tlg8DnkCm4nI57RJGP8Mf6BaXPIJkHX8yjcefK2RlDA==",
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.23.tgz",
-      "integrity": "sha512-eQSN+JJqx/5Dk2C5uet2l7HifGsDBorQHD3PAVnge5jxl+rXU/zbzX9Un56+uuUB0QYeS4Dyr8cN7NHuIKGxBA==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.102.tgz",
+      "integrity": "sha512-X5akDkHwk6oAer49oER0qZMjNMkLH3IOZaV1m98uXIasAGyjo5WH1MKPeMLY1sY6V6TrufzwiSwD4ds571ytcg==",
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.23.tgz",
-      "integrity": "sha512-zxYvggbw6R/sTNey0qgsigFMY59DYepm1+JNojxOKjbnvxmgyeIa5sPdu/5gLj0TtJOiWvSGrpMPNUIVreUSGA==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.102.tgz",
+      "integrity": "sha512-kJH3XtZP9YQdjq/wYVBeFuiVQl4HaC4WwRrIxAHwe2OyvrwUI43dpW3LpxSggBnxXcVCXYWf36sTnv8S75o2Gw==",
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.23.tgz",
-      "integrity": "sha512-l8UWhcNvZ6RzNZBBToMYuKYijF0h7mbw2RuFV5rpCYF/k/Wh85PaDHPQIQ6qjMHJsIBHYXUt0HLAP+fiAfBiDw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.102.tgz",
+      "integrity": "sha512-flQP2WDyCgO24WmKA1wjjTx+xfCmavUete2Kp6yrM+631IHLGnr17eu7rYJ/d4EnDBId/ytMyrnWbTVkaVrpbQ==",
       "optional": true
     },
     "@swc/core-linux-arm64-musl": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.23.tgz",
-      "integrity": "sha512-TZDPp1wUE1ynVyY0vwIToyOULKEQ91H49R+p6Iu/2YY+UQQwUamhX0Gp8O85RT+j72/iHyhbQkz7yRg6v+GB5A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.102.tgz",
+      "integrity": "sha512-bQEQSnC44DyoIGLw1+fNXKVGoCHi7eJOHr8BdH0y1ooy9ArskMjwobBFae3GX4T1AfnrTaejyr0FvLYIb0Zkog==",
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.23.tgz",
-      "integrity": "sha512-rKqWnOmUyQfoKZuuXs/S0RNobN+kcUyMtwoCdRdCNqOlk1XZRCMpjGc9Aqn73K3xlZ6JXX6oLrXKn375b2dydw==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.102.tgz",
+      "integrity": "sha512-dFvnhpI478svQSxqISMt00MKTDS0e4YtIr+ioZDG/uJ/q+RpcNy3QI2KMm05Fsc8Y0d4krVtvCKWgfUMsJZXAg==",
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.23.tgz",
-      "integrity": "sha512-1MK9eocIhuIr/+yUKnTNHpYovMQvfKTJQbU4UMfQLg2qyCGKAvO+jOy5JIGR9x04MWqz9U3EHHS/7Id35ekhFQ==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.102.tgz",
+      "integrity": "sha512-+a0M3CvjeIRNA/jTCzWEDh2V+mhKGvLreHOL7J97oULZy5yg4gf7h8lQX9J8t9QLbf6fsk+0F8bVH1Ie/PbXjA==",
       "optional": true
     },
     "@swc/core-win32-arm64-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.23.tgz",
-      "integrity": "sha512-3nmdugj0SJIGWeCJBhvPWIfnE2Ax8H2KZsJfcaWmWg0SDh19aAt48Ncyd8WHHBandJmVm2fSjaANSjp+cS2S9A==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.102.tgz",
+      "integrity": "sha512-w76JWLjkZNOfkB25nqdWUNCbt0zJ41CnWrJPZ+LxEai3zAnb2YtgB/cCIrwxDebRuMgE9EJXRj7gDDaTEAMOOQ==",
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.23.tgz",
-      "integrity": "sha512-2AlGRhys1BsfLjXyWOd+5J/Ko2kkVQVuy3ZR8OBGy7XI54p0PpepabloYI9irr+4bi9vtyxoc5rS21PmJxB83Q==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.102.tgz",
+      "integrity": "sha512-vlDb09HiGqKwz+2cxDS9T5/461ipUQBplvuhW+cCbzzGuPq8lll2xeyZU0N1E4Sz3MVdSPx1tJREuRvlQjrwNg==",
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.3.23",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.23.tgz",
-      "integrity": "sha512-qYKP8sIM7VVLuDb5BkRBoHy28OHZWrUhPTO7WgpErhVVM9wnzmMi/Jgg8SyfMy6oheBjO0QiwWbXONxBwByjnQ==",
+      "version": "1.3.102",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.102.tgz",
+      "integrity": "sha512-E/jfSD7sShllxBwwgDPeXp1UxvIqehj/ShSUqq1pjR/IDRXngcRSXKJK92mJkNFY7suH6BcCWwzrxZgkO7sWmw==",
       "optional": true
     },
+    "@swc/counter": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
+      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw=="
+    },
+    "@swc/types": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
+      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw=="
+    },
     "@temporalio/activity": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.5.2.tgz",
-      "integrity": "sha512-At25g+m0aMuS00VvH1m4p6yzFFpY+CfJWY1jLifcDcfnwJj+o6EiHxtRaylGufDVtZShDAHB/j8W0a1xFgSrPg==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-1.9.0.tgz",
+      "integrity": "sha512-a9bLEUAM/Y8oInFvmjQPOHnTobp4dX6u7Y61Q0eFtuGQsVb4G51UtXAUtxhgn9lZJv37Tjw+K6yvXYjt4vsSXg==",
       "requires": {
-        "@temporalio/common": "^1.5.2",
+        "@temporalio/common": "1.9.0",
         "abort-controller": "^3.0.0"
       }
     },
     "@temporalio/client": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.5.2.tgz",
-      "integrity": "sha512-pzu3KPVX+n+YXccoQuUGXlx7EyPf9eadgfwrlezJ+gQx67FlEq9bLJ0xmprfwhANIBtcFs5jcUHKWWPHzrIqqA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-1.9.0.tgz",
+      "integrity": "sha512-8J2ZJe4xaWpq648657oUfNW/moNqgRL3ARq2oxRWH+g0qBOYKvUhGI7xTJSbuA2+s7sSbRyOX7WBnkT5r9ce5A==",
       "requires": {
-        "@grpc/grpc-js": "^1.6.7",
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/proto": "^1.5.2",
+        "@grpc/grpc-js": "~1.7.3",
+        "@temporalio/common": "1.9.0",
+        "@temporalio/proto": "1.9.0",
         "abort-controller": "^3.0.0",
-        "long": "^5.2.0",
-        "uuid": "^8.3.2"
+        "long": "^5.2.3",
+        "uuid": "^9.0.1"
       }
     },
     "@temporalio/common": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.5.2.tgz",
-      "integrity": "sha512-sBh+U48ad8k2lvRxOQCfjtF5BKOE+DhgsC7tcRnT3IbKyJXOfbd9KIjpSWHqZZLP19Ah7C8fkDC0faSBHtBaYQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-1.9.0.tgz",
+      "integrity": "sha512-x7Rmarsy5uOT91lla0p777CFc+uNX62Vgb0FHOcR2X7o1rFl1BPKY9A1Ew7nt28Po59aNbCbdhLykksq4e3yng==",
       "requires": {
-        "@opentelemetry/api": "^1.0.3",
-        "@temporalio/proto": "^1.5.2",
-        "long": "^5.2.0",
-        "ms": "^2.1.3",
-        "proto3-json-serializer": "^1.0.3",
-        "protobufjs": "^7.0.0"
+        "@temporalio/proto": "1.9.0",
+        "long": "^5.2.3",
+        "ms": "^3.0.0-canary.1",
+        "proto3-json-serializer": "^2.0.0"
+      },
+      "dependencies": {
+        "proto3-json-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
+          "integrity": "sha512-FB/YaNrpiPkyQNSNPilpn8qn0KdEfkgmJ9JP93PQyF/U4bAiXY5BiUdDhiDO4S48uSQ6AesklgVlrKiqZPzegw==",
+          "requires": {
+            "protobufjs": "^7.0.0"
+          }
+        }
       }
     },
     "@temporalio/core-bridge": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.5.2.tgz",
-      "integrity": "sha512-aLsWCGWOH1Vi6q8kLdETzfuWBlDPr5FVZeulW5EZBWU6+ElklD50eVEko4V2Lp+3n/tpIS5k52a1oCIZZrm/Jw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-1.9.0.tgz",
+      "integrity": "sha512-QFsYgKOvp2aGjanEMonY4zp/4MaCbFh8cOuGkFf2yFoANqbeMAUC7zwczaK9XN7m+LhyaQCZOYHgnZePPJIp3g==",
       "requires": {
-        "@opentelemetry/api": "^1.1.0",
-        "@temporalio/common": "^1.5.2",
+        "@temporalio/common": "1.9.0",
         "arg": "^5.0.2",
-        "cargo-cp-artifact": "^0.1.6",
-        "which": "^2.0.2"
+        "cargo-cp-artifact": "^0.1.8",
+        "which": "^4.0.0"
+      },
+      "dependencies": {
+        "isexe": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+          "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="
+        },
+        "which": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+          "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+          "requires": {
+            "isexe": "^3.1.1"
+          }
+        }
       }
     },
     "@temporalio/proto": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.5.2.tgz",
-      "integrity": "sha512-yi9sktBF7EVM1wfh8IZe0iaz54zXpnfUD7zGsdWc7MyXZfl0Ub9Qrx7CxPVJSk+qbvQAx/2OpRzaFgXnyIkhEA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-1.9.0.tgz",
+      "integrity": "sha512-jfSo/NSEjBXvCwl55A+e7zuJ90ZbAcvU16+4/bLCL6H/8JTDvafVimPcvYi6UQwJZcQMUsKegu8q36HWw/jfgQ==",
       "requires": {
-        "long": "^5.2.0",
-        "protobufjs": "^7.0.0"
+        "long": "^5.2.3",
+        "protobufjs": "^7.2.5"
       }
     },
     "@temporalio/worker": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.5.2.tgz",
-      "integrity": "sha512-t+3uM3b1FOOciJFfEl20h6s51xuYOLOaQv0qAkDMqCJNN+ZTCsYdOpXBrYok/3wDLqAc9acTZczoFvBh7sF6HA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-1.9.0.tgz",
+      "integrity": "sha512-ekrmJ/rpM+ErBe7jCBZ1FSf0iAThlMgZ5ez/B02Coy+L7HPVG3MH2hiYi1t6SPcl8zviZbb7vIGTaV0SnWwQYg==",
       "requires": {
-        "@opentelemetry/api": "^1.1.0",
-        "@swc/core": "^1.2.204",
-        "@temporalio/activity": "^1.5.2",
-        "@temporalio/client": "^1.5.2",
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/core-bridge": "^1.5.2",
-        "@temporalio/proto": "^1.5.2",
-        "@temporalio/workflow": "^1.5.2",
+        "@swc/core": "^1.3.102",
+        "@temporalio/activity": "1.9.0",
+        "@temporalio/client": "1.9.0",
+        "@temporalio/common": "1.9.0",
+        "@temporalio/core-bridge": "1.9.0",
+        "@temporalio/proto": "1.9.0",
+        "@temporalio/workflow": "1.9.0",
         "abort-controller": "^3.0.0",
-        "cargo-cp-artifact": "^0.1.6",
-        "heap-js": "^2.2.0",
-        "memfs": "^3.4.6",
-        "ms": "^2.1.3",
-        "rxjs": "^7.5.5",
-        "semver": "^7.3.7",
+        "heap-js": "^2.3.0",
+        "memfs": "^4.6.0",
+        "rxjs": "^7.8.1",
         "source-map": "^0.7.4",
-        "source-map-loader": "^4.0.0",
+        "source-map-loader": "^4.0.2",
         "swc-loader": "^0.2.3",
-        "terser": "^5.14.2",
-        "unionfs": "^4.4.0",
-        "webpack": "^5.73.0"
+        "unionfs": "^4.5.1",
+        "webpack": "^5.89.0"
       }
     },
     "@temporalio/workflow": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.5.2.tgz",
-      "integrity": "sha512-MhGV+vdq+3kdsTBr77G3IGoNoJr9Q5xbhXD9LDuKgD+gBgoDZv09QX4n0AQvMh5Kgks36fV/E7ZIYVgfEKsNRA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-1.9.0.tgz",
+      "integrity": "sha512-0/9b8bUbtVdvuV9t7BQ7Ki/SVi9y2HnymO70SaT05x2t2aXS8BuW7q73vwIPoKazFdvNK7LA1nNcZ3Kgz9iz8w==",
       "requires": {
-        "@temporalio/common": "^1.5.2",
-        "@temporalio/proto": "^1.5.2"
+        "@temporalio/common": "1.9.0",
+        "@temporalio/proto": "1.9.0"
       }
     },
     "@tsconfig/node10": {
@@ -4056,11 +4198,6 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
       "version": "18.11.17",
@@ -4362,11 +4499,6 @@
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
-    "abab": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4509,9 +4641,9 @@
       "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
     },
     "cargo-cp-artifact": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.7.tgz",
-      "integrity": "sha512-pxEV9p1on8vu3BOKstVisF9TwMyGKCBRvzaVpQHuU2sLULCKrn3MJWx/4XlNzmG6xNCTPf78DJ7WCGgr2mOzjg=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.8.tgz",
+      "integrity": "sha512-3j4DaoTrsCD1MRkTF2Soacii0Nx7UHCce0EwUf4fHnggwiE4fbmF2AbnfzayR36DF8KGadfh7M/Yfy625kgPlA=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -4529,12 +4661,12 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
       }
     },
@@ -4889,6 +5021,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "peer": true
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -4957,9 +5095,9 @@
       "dev": true
     },
     "fs-monkey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz",
-      "integrity": "sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.5.tgz",
+      "integrity": "sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -5055,9 +5193,14 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
     },
     "heap-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.2.0.tgz",
-      "integrity": "sha512-G3uM72G9F/zo9Hph/T7m4ZZVlVu5bx2f5CiCS78TBHz2mNIXnB5KRdEEYssXZJ7ldLDqID29bZ1D5ezCKQD2Zw=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.3.0.tgz",
+      "integrity": "sha512-E5303mzwQ+4j/n2J0rDvEPBN7GKjhis10oHiYOgjxsmxYgqG++hz9NyLLOXttzH8as/DyiBHYpUrJTZWYaMo8Q=="
+    },
+    "hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A=="
     },
     "iconv-lite": {
       "version": "0.6.3",
@@ -5143,7 +5286,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
     },
     "jest-worker": {
       "version": "27.5.1",
@@ -5185,6 +5329,15 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
+      }
+    },
+    "json-joy": {
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/json-joy/-/json-joy-9.9.1.tgz",
+      "integrity": "sha512-/d7th2nbQRBQ/nqTkBe6KjjvDciSwn9UICmndwk3Ed/Bk9AqkTRm4PnLVfXG4DKbT0rEY0nKnwE7NqZlqKE6kg==",
+      "requires": {
+        "arg": "^5.0.2",
+        "hyperdyperid": "^1.2.0"
       }
     },
     "json-parse-even-better-errors": {
@@ -5232,6 +5385,18 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "peer": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "peer": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5245,14 +5410,15 @@
       "dev": true
     },
     "long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5264,11 +5430,12 @@
       "dev": true
     },
     "memfs": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.12.tgz",
-      "integrity": "sha512-BcjuQn6vfqP+k100e0E9m61Hyqa//Brp+I3f0OBmN0ATHlFA8vx3Lt8z57R3u2bPqe3WGDBC+nF72fTH7isyEw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.6.0.tgz",
+      "integrity": "sha512-I6mhA1//KEZfKRQT9LujyW6lRbX7RkC24xKododIDO3AGShcaFAMKElv1yFGWX8fD4UaSiwasr3NeQ5TdtHY1A==",
       "requires": {
-        "fs-monkey": "^1.0.3"
+        "json-joy": "^9.2.0",
+        "thingies": "^1.11.1"
       }
     },
     "merge-stream": {
@@ -5321,9 +5488,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5435,9 +5602,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5463,6 +5630,17 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
+    },
+    "quill-delta": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+      "peer": true,
+      "requires": {
+        "fast-diff": "^1.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isequal": "^4.5.0"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5530,9 +5708,9 @@
       }
     },
     "rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "requires": {
         "tslib": "^2.1.0"
       }
@@ -5561,6 +5739,7 @@
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -5616,11 +5795,10 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-loader": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.1.tgz",
-      "integrity": "sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-4.0.2.tgz",
+      "integrity": "sha512-oYwAqCuL0OZhBoSgmdrLa7mv9MjommVMiQIWgcztf+eS4+8BfcUee6nenFnDhKOhzAVnk5gpZdfnz1iiBv+5sg==",
       "requires": {
-        "abab": "^2.0.6",
         "iconv-lite": "^0.6.3",
         "source-map-js": "^1.0.2"
       }
@@ -5771,6 +5949,12 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "thingies": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.15.0.tgz",
+      "integrity": "sha512-ZSJlvEpD8QllYim0VSGlbAoob/iPrTWNlV/m8ltizMvMmzzU2gVJvHfH9ijLstyciWF70ZiQXqz+BCXWJq+ZQw==",
+      "requires": {}
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5871,9 +6055,9 @@
       "dev": true
     },
     "unionfs": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.4.0.tgz",
-      "integrity": "sha512-N+TuJHJ3PjmzIRCE1d2N3VN4qg/P78eh/nxzwHnzpg3W2Mvf8Wvi7J1mvv6eNkb8neUeSdFSQsKna0eXVyF4+w==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.5.1.tgz",
+      "integrity": "sha512-hn8pzkh0/80mpsIT/YBJKa4+BF/9pNh0IgysBi0CjL95Uok8Hus69TNfgeJckoUNwfTpBq26+F7edO1oBINaIw==",
       "requires": {
         "fs-monkey": "^1.0.0"
       }
@@ -5896,9 +6080,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -5922,9 +6106,9 @@
       }
     },
     "webpack": {
-      "version": "5.88.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.1.tgz",
-      "integrity": "sha512-FROX3TxQnC/ox4N+3xQoWZzvGXSuscxR32rbzjpXgEzWudJFEJBpdlkkob2ylrv5yzzufD1zph1OoFsLtm6stQ==",
+      "version": "5.89.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -5974,6 +6158,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -6008,26 +6193,27 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       }
     },
     "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "dependencies": {
     "@protobuf-ts/protoc": "^2.8.1",
-    "@temporalio/activity": "^1.5.2",
-    "@temporalio/client": "^1.5.2",
-    "@temporalio/common": "^1.5.2",
-    "@temporalio/worker": "^1.5.2",
-    "@temporalio/workflow": "^1.5.2",
+    "@temporalio/activity": "^1.9.0",
+    "@temporalio/client": "^1.9.0",
+    "@temporalio/common": "^1.9.0",
+    "@temporalio/worker": "^1.9.0",
+    "@temporalio/workflow": "^1.9.0",
     "commander": "^8.3.0",
     "proto3-json-serializer": "^1.1.1"
   },

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -113,7 +113,11 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
 			packageJSONDepStr += "\n    "
 		}
 	} else {
-		packageJSONDepStr = `"temporalio": "` + strings.TrimPrefix(options.Version, "v") + "\",\n    "
+		version := strings.TrimPrefix(options.Version, "v")
+		pkgs := []string{"activity", "client", "common", "worker", "workflow"}
+		for _, pkg := range pkgs {
+			packageJSONDepStr += fmt.Sprintf(`    "@temporalio/%v": %q,`, pkg, version) + "\n"
+		}
 	}
 	moreDeps := ""
 	for dep, version := range options.MoreDependencies {
@@ -130,7 +134,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
     ` + packageJSONDepStr + `
 	` + moreDeps + `
     "commander": "^8.3.0",
-	"proto3-json-serializer": "^1.1.1",
+    "proto3-json-serializer": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The other SDKs do it and this test fails with the new server behavior of returning a failed precondition error if not pollers have been seen just before the deadline exceeds.

https://github.com/temporalio/temporal/pull/5252