### PR TITLE
Gather SDK versions into a single place in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,14 +6,6 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
 
-# Don't add 'v' in front of version numbers
-env:
-  GO_LATEST: '77626eee301574bc4cfd756dbf0641c61e9e6907'
-  TYPESCRIPT_LATEST: '1.9.0'
-  JAVA_LATEST: '1.22.0'
-  PYTHON_LATEST: '1.4.0'
-  CSHARP_LATEST: '0.1.0-beta2'
-
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -102,55 +94,69 @@ jobs:
       - run: dotnet build
       - run: dotnet test
 
+  latest-sdk-versions:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      go_latest: '77626eee301574bc4cfd756dbf0641c61e9e6907'
+      typescript_latest: '1.9.0'
+      java_latest: '1.22.0'
+      python_latest: '1.4.0'
+      csharp_latest: '0.1.0-beta2'
+
   feature-tests-ts:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/typescript.yaml
     with:
-      version: ${{ env.TYPESCRIPT_LATEST }}
+      version: ${{ needs.latest-sdk-versions.outputs.typescript_latest }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-go:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/go.yaml
     with:
-      # First commit that supports the new temporalproto APIs
-      version: ${{ env.GO_LATEST }}
+      version: ${{ needs.latest-sdk-versions.outputs.go_latest }}
       version-is-repo-ref: true
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-python:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/python.yaml
     with:
-      version: ${{ env.PYTHON_LATEST }}
+      version: ${{ needs.latest-sdk-versions.outputs.python_latest }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-java:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/java.yaml
     with:
-      version: 'v${{ env.JAVA_LATEST }}'
+      version: 'v${{ needs.latest-sdk-versions.outputs.java_latest }}'
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-dotnet:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/dotnet.yaml
     with:
-      version: ${{ env.CSHARP_LATEST }}
+      version: ${{ needs.latest-sdk-versions.outputs.csharp_latest }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   build-docker-images:
+    needs: latest-sdk-versions
     uses: ./.github/workflows/all-docker-images.yaml
     secrets: inherit
     # TODO: Find some way to automatically upgrade to "latest"
     with:
       do-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      go-repo-ref: ${{ env.GO_LATEST }}
-      ts-ver: 'v${{ env.TYPESCRIPT_LATEST }}'
-      java-ver: 'v${{ env.JAVA_LATEST }}'
-      py-ver: 'v${{ env.PYTHON_LATEST }}'
-      cs-ver: 'v${{ env.CSHARP_LATEST }}'
+      go-repo-ref: ${{ needs.latest-sdk-versions.outputs.go_latest }}
+      ts-ver: 'v${{ needs.latest-sdk-versions.outputs.typescript_latest }}'
+      java-ver: 'v${{ needs.latest-sdk-versions.outputs.java_latest }}'
+      py-ver: 'v${{ needs.latest-sdk-versions.outputs.python_latest }}'
+      cs-ver: 'v${{ needs.latest-sdk-versions.outputs.csharp_latest }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,7 +105,7 @@ jobs:
   feature-tests-ts:
     uses: ./.github/workflows/typescript.yaml
     with:
-      version: ${{ github.env.TYPESCRIPT_LATEST }}
+      version: ${{ env.TYPESCRIPT_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/go.yaml
     with:
       # First commit that supports the new temporalproto APIs
-      version: ${{ github.env.GO_LATEST }}
+      version: ${{ env.GO_LATEST }}
       version-is-repo-ref: true
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -122,7 +122,7 @@ jobs:
   feature-tests-python:
     uses: ./.github/workflows/python.yaml
     with:
-      version: ${{ github.env.PYTHON_LATEST }}
+      version: ${{ env.PYTHON_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -130,7 +130,7 @@ jobs:
   feature-tests-java:
     uses: ./.github/workflows/java.yaml
     with:
-      version: 'v${{ github.env.JAVA_LATEST }}'
+      version: 'v${{ env.JAVA_LATEST }}'
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -138,7 +138,7 @@ jobs:
   feature-tests-dotnet:
     uses: ./.github/workflows/dotnet.yaml
     with:
-      version: ${{ github.env.CSHARP_LATEST }}
+      version: ${{ env.CSHARP_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -149,8 +149,8 @@ jobs:
     # TODO: Find some way to automatically upgrade to "latest"
     with:
       do-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      go-repo-ref: ${{ github.env.GO_LATEST }}
-      ts-ver: 'v${{ github.env.TYPESCRIPT_LATEST }}'
-      java-ver: 'v${{ github.env.JAVA_LATEST }}'
-      py-ver: 'v${{ github.env.PYTHON_LATEST }}'
-      cs-ver: 'v${{ github.env.CSHARP_LATEST }}'
+      go-repo-ref: ${{ env.GO_LATEST }}
+      ts-ver: 'v${{ env.TYPESCRIPT_LATEST }}'
+      java-ver: 'v${{ env.JAVA_LATEST }}'
+      py-ver: 'v${{ env.PYTHON_LATEST }}'
+      cs-ver: 'v${{ env.CSHARP_LATEST }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,14 @@ on: # rebuild any PRs and main branch changes
     branches:
       - main
 
+# Don't add 'v' in front of version numbers
+env:
+  GO_LATEST: '77626eee301574bc4cfd756dbf0641c61e9e6907'
+  TYPESCRIPT_LATEST: '1.9.0'
+  JAVA_LATEST: '1.22.0'
+  PYTHON_LATEST: '1.4.0'
+  CSHARP_LATEST: '0.1.0-beta2'
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -97,7 +105,7 @@ jobs:
   feature-tests-ts:
     uses: ./.github/workflows/typescript.yaml
     with:
-      version: 1.9.0
+      version: ${{ github.env.TYPESCRIPT_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -106,7 +114,7 @@ jobs:
     uses: ./.github/workflows/go.yaml
     with:
       # First commit that supports the new temporalproto APIs
-      version: 77626eee301574bc4cfd756dbf0641c61e9e6907
+      version: ${{ github.env.GO_LATEST }}
       version-is-repo-ref: true
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -114,7 +122,7 @@ jobs:
   feature-tests-python:
     uses: ./.github/workflows/python.yaml
     with:
-      version: 1.4.0
+      version: ${{ github.env.PYTHON_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -122,7 +130,7 @@ jobs:
   feature-tests-java:
     uses: ./.github/workflows/java.yaml
     with:
-      version: v1.21.1
+      version: 'v${{ github.env.JAVA_LATEST }}'
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -130,7 +138,7 @@ jobs:
   feature-tests-dotnet:
     uses: ./.github/workflows/dotnet.yaml
     with:
-      version: 0.1.0-beta2
+      version: ${{ github.env.CSHARP_LATEST }}
       version-is-repo-ref: false
       features-repo-ref: ${{ github.head_ref }}
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
@@ -141,8 +149,8 @@ jobs:
     # TODO: Find some way to automatically upgrade to "latest"
     with:
       do-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      go-repo-ref: '77626eee301574bc4cfd756dbf0641c61e9e6907'
-      ts-ver: 'v1.9.0'
-      java-ver: 'v1.22.0'
-      py-ver: 'v1.4.0'
-      cs-ver: 'v0.1.0-beta2'
+      go-repo-ref: ${{ github.env.GO_LATEST }}
+      ts-ver: 'v${{ github.env.TYPESCRIPT_LATEST }}'
+      java-ver: 'v${{ github.env.JAVA_LATEST }}'
+      py-ver: 'v${{ github.env.PYTHON_LATEST }}'
+      cs-ver: 'v${{ github.env.CSHARP_LATEST }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,8 @@ jobs:
       java_latest: '1.22.0'
       python_latest: '1.4.0'
       csharp_latest: '0.1.0-beta2'
+    steps:
+      - run: 'echo noop'
 
   feature-tests-ts:
     needs: latest-sdk-versions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  latest-sdk-versions:
+    runs-on: 'ubuntu-latest'
+    outputs:
+      go_latest: '77626eee301574bc4cfd756dbf0641c61e9e6907'
+      typescript_latest: '1.9.0'
+      java_latest: '1.22.0'
+      python_latest: '1.4.0'
+      csharp_latest: '0.1.0-beta2'
+    steps:
+      - run: 'echo noop'
+
   # Build cli and harnesses
   build-go:
     strategy:
@@ -93,17 +104,6 @@ jobs:
       - uses: actions/setup-dotnet@v3
       - run: dotnet build
       - run: dotnet test
-
-  latest-sdk-versions:
-    runs-on: 'ubuntu-latest'
-    outputs:
-      go_latest: '77626eee301574bc4cfd756dbf0641c61e9e6907'
-      typescript_latest: '1.9.0'
-      java_latest: '1.22.0'
-      python_latest: '1.4.0'
-      csharp_latest: '0.1.0-beta2'
-    steps:
-      - run: 'echo noop'
 
   feature-tests-ts:
     needs: latest-sdk-versions


### PR DESCRIPTION
## What was changed

- In ci.yaml, moved SDK version numbers to a single block, at the top of the file, then reuse those version numbers as variables across the file.

## Why?

- Makes it easier to update version number from an automated script (e.g. using sed or similar).
- Avoid risk of incoherencies (i.e. different version numbers in `build-docker-images` vs `feature-tests-somelang`.