### PR TITLE
Enable workflow update in server integration tests

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -88,8 +88,8 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
 
       - name: Run SDK-features tests directly
@@ -101,10 +101,10 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-cs features-tests-cs
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f /tmp/server-docker/docker-compose.yml -f ./dockerfiles/docker-compose.for-server-image.yaml down -v
+        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,8 +70,8 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
 
       - name: Run SDK-features tests directly
@@ -85,10 +85,10 @@ jobs:
           WAIT_EXTRA_FOR_NAMESPACE: true
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-go features-tests-go
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f /tmp/server-docker/docker-compose.yml -f ./dockerfiles/docker-compose.for-server-image.yaml down -v
+        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -76,8 +76,8 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
 
       - name: Run SDK-features tests directly
@@ -89,10 +89,10 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-java features-tests-java
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f /tmp/server-docker/docker-compose.yml -f ./dockerfiles/docker-compose.for-server-image.yaml down -v
+        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -95,8 +95,8 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
 
       - name: Run SDK-features tests directly
@@ -108,10 +108,10 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-py features-tests-py
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f /tmp/server-docker/docker-compose.yml -f ./dockerfiles/docker-compose.for-server-image.yaml down -v
+        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -95,8 +95,8 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
 
       - name: Run SDK-features tests directly
@@ -108,10 +108,10 @@ jobs:
         if: inputs.docker-image-artifact-name
         run: |
           docker-compose \
-            -f /tmp/server-docker/docker-compose.yml \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
+            -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-ts features-tests-ts
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f /tmp/server-docker/docker-compose.yml -f ./dockerfiles/docker-compose.for-server-image.yaml down -v
+        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/dockerfiles/docker-compose.for-server-image.yaml
+++ b/dockerfiles/docker-compose.for-server-image.yaml
@@ -10,6 +10,8 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
+    volumes:
+      - ./dynamicconfig:/etc/temporal/config/dynamicconfig
     ports:
       - '7233:7233'
     depends_on:

--- a/dockerfiles/dynamicconfig/docker.yaml
+++ b/dockerfiles/dynamicconfig/docker.yaml
@@ -1,0 +1,6 @@
+frontend.enableUpdateWorkflowExecution:
+  - value: true
+    constraints: {}
+frontend.enableUpdateWorkflowExecutionAsyncAccepted:
+  - value: true
+    constraints: {}


### PR DESCRIPTION
> When you use multiple Compose files, all paths in the files are relative to the first configuration file specified with `-f`. You can use the `--project-directory` option to override this base path.

In continuation of #407, #408, #409.

Run locally:
```
dockerfiles-features-tests-go-1  | 2024-01-18T22:10:27.871Z     INFO    harness/log.go:48       All features passed

```