### PR TITLE
Add missing dependency in generated package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,11 @@
         "@temporalio/worker": "^1.9.0",
         "@temporalio/workflow": "^1.9.0",
         "commander": "^8.3.0",
-        "ms": "^2.1.3",
+        "ms": "^3.0.0-canary.1",
         "proto3-json-serializer": "^1.1.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.0",
-        "@types/ms": "^0.7.34",
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
         "eslint": "^7.32.0",
@@ -631,14 +630,6 @@
         "proto3-json-serializer": "^2.0.0"
       }
     },
-    "node_modules/@temporalio/common/node_modules/ms": {
-      "version": "3.0.0-canary.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
-      "engines": {
-        "node": ">=12.13"
-      }
-    },
     "node_modules/@temporalio/common/node_modules/proto3-json-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
@@ -784,12 +775,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "node_modules/@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -2552,9 +2537,12 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g==",
+      "engines": {
+        "node": ">=12.13"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4077,11 +4065,6 @@
         "proto3-json-serializer": "^2.0.0"
       },
       "dependencies": {
-        "ms": {
-          "version": "3.0.0-canary.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
-          "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
-        },
         "proto3-json-serializer": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.0.tgz",
@@ -4215,12 +4198,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "@types/ms": {
-      "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
       "dev": true
     },
     "@types/node": {
@@ -5512,9 +5489,9 @@
       "dev": true
     },
     "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "version": "3.0.0-canary.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-3.0.0-canary.1.tgz",
+      "integrity": "sha512-kh8ARjh8rMN7Du2igDRO9QJnqCb2xYTJxyQYK7vJJS4TvLLmsbyhiKpSW+t+y26gyOyMd0riphX0GeWKU3ky5g=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "@temporalio/worker": "^1.9.0",
     "@temporalio/workflow": "^1.9.0",
     "commander": "^8.3.0",
-    "ms": "^2.1.3",
+    "ms": "^3.0.0-canary.1",
     "proto3-json-serializer": "^1.1.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
-    "@types/ms": "^0.7.34",
     "@typescript-eslint/eslint-plugin": "^4.30.0",
     "@typescript-eslint/parser": "^4.30.0",
     "eslint": "^7.32.0",

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -134,11 +134,13 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
     ` + packageJSONDepStr + `
 	` + moreDeps + `
     "commander": "^8.3.0",
+    "ms": "^2.1.3",
     "proto3-json-serializer": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
+    "@types/ms": "^0.7.34",
     "@types/node": "^16.11.59",
     "@types/uuid": "^8.3.4",
     "tsconfig-paths": "^3.12.0",

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -134,13 +134,12 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
     ` + packageJSONDepStr + `
 	` + moreDeps + `
     "commander": "^8.3.0",
-    "ms": "^2.1.3",
+    "ms": "^3.0.0-canary.1",
     "proto3-json-serializer": "^1.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",
-    "@types/ms": "^0.7.34",
     "@types/node": "^16.11.59",
     "@types/uuid": "^8.3.4",
     "tsconfig-paths": "^3.12.0",


### PR DESCRIPTION
## What changed

- Added the `ms` dependency was missing in generated package.json files. We missed it in #362, which is now causing CI errors on the TS SDK repo.