### PR TITLE
Add test that repros TS crash due to proto changes

### DIFF
--- a/features/activity/basic_no_workflow_timeout/README.md
+++ b/features/activity/basic_no_workflow_timeout/README.md
@@ -1,0 +1,9 @@
+# Basic activity
+The most basic workflow which just runs an activity and returns its result.
+Importantly, without setting a workflow execution timeout.
+
+
+# Detailed spec
+It's important that the workflow execution timeout is not set here, because server will propagate that to all un-set
+activity timeouts. We had a bug where TS would crash (after proto changes from gogo to google) because it was expecting
+timeouts to be set to zero rather than null.

--- a/features/activity/basic_no_workflow_timeout/feature.cs
+++ b/features/activity/basic_no_workflow_timeout/feature.cs
@@ -1,0 +1,54 @@
+namespace activity.basic_no_workflow_timeout;
+
+using Temporalio.Activities;
+using Temporalio.Client;
+using Temporalio.Exceptions;
+using Temporalio.Features.Harness;
+using Temporalio.Worker;
+using Temporalio.Workflows;
+
+class Feature : IFeature
+{
+    public void ConfigureWorker(Runner runner, TemporalWorkerOptions options) =>
+        options.AddWorkflow<MyWorkflow>().AddAllActivities(new MyActivities(runner.Client));
+
+    [Workflow]
+    class MyWorkflow
+    {
+        private string? activityResult;
+
+        [WorkflowRun]
+        public async Task RunAsync()
+        {
+            await Workflow.ExecuteActivityAsync(
+                (MyActivities act) => act.Echo(),
+                new()
+                {
+                    ScheduleToCloseTimeout = TimeSpan.FromMinutes(1)
+                });
+
+            await Workflow.ExecuteActivityAsync(
+                (MyActivities act) => act.Echo(),
+                new()
+                {
+                    StartToCloseTimeout = TimeSpan.FromMinutes(1)
+                });
+        }
+
+        [WorkflowSignal]
+        public async Task SetActivityResultAsync(string res) => activityResult = res;
+    }
+
+    class MyActivities
+    {
+        private readonly ITemporalClient client;
+
+        public MyActivities(ITemporalClient client) => this.client = client;
+
+        [Activity]
+        public async Task<string> Echo()
+        {
+            return "hi";
+        }
+    }
+}

--- a/features/activity/basic_no_workflow_timeout/feature.go
+++ b/features/activity/basic_no_workflow_timeout/feature.go
@@ -18,14 +18,20 @@ var Feature = harness.Feature{
 }
 
 func Workflow(ctx workflow.Context) (string, error) {
-	// Allow 4 retries with no backoff
 	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		StartToCloseTimeout: 1 * time.Minute,
 	})
 
-	// Execute activity and return error
 	var result string
 	err := workflow.ExecuteActivity(ctx, Echo).Get(ctx, &result)
+	if err != nil {
+		return "", err
+	}
+
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		ScheduleToCloseTimeout: 1 * time.Minute,
+	})
+	err = workflow.ExecuteActivity(ctx, Echo).Get(ctx, &result)
 	return result, err
 }
 

--- a/features/activity/basic_no_workflow_timeout/feature.go
+++ b/features/activity/basic_no_workflow_timeout/feature.go
@@ -1,0 +1,34 @@
+package retry_on_error
+
+import (
+	"context"
+	"time"
+
+	"github.com/temporalio/features/harness/go/harness"
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/workflow"
+)
+
+var Feature = harness.Feature{
+	Workflows:  Workflow,
+	Activities: Echo,
+	StartWorkflowOptionsMutator: func(o *client.StartWorkflowOptions) {
+		o.WorkflowExecutionTimeout = 0
+	},
+}
+
+func Workflow(ctx workflow.Context) (string, error) {
+	// Allow 4 retries with no backoff
+	ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+		StartToCloseTimeout: 1 * time.Minute,
+	})
+
+	// Execute activity and return error
+	var result string
+	err := workflow.ExecuteActivity(ctx, Echo).Get(ctx, &result)
+	return result, err
+}
+
+func Echo(_ context.Context) (string, error) {
+	return "echo", nil
+}

--- a/features/activity/basic_no_workflow_timeout/feature.java
+++ b/features/activity/basic_no_workflow_timeout/feature.java
@@ -15,13 +15,17 @@ public interface feature extends Feature, SimpleWorkflow {
   class Impl implements feature {
     @Override
     public void workflow() {
-      // Allow 4 retries with no backoff
       var activities =
           activities(
               feature.class, builder -> builder.setStartToCloseTimeout(Duration.ofMinutes(1)));
 
-      // Execute activity
       activities.echo();
+
+      var activitiesSched2Close =
+          activities(
+              feature.class, builder -> builder.setScheduleToCloseTimeout(Duration.ofMinutes(1)));
+
+      activitiesSched2Close.echo();
     }
 
     @Override

--- a/features/activity/basic_no_workflow_timeout/feature.java
+++ b/features/activity/basic_no_workflow_timeout/feature.java
@@ -1,0 +1,37 @@
+package activity.basic_no_workflow_timeout;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.sdkfeatures.Feature;
+import io.temporal.sdkfeatures.SimpleWorkflow;
+import java.time.Duration;
+
+@ActivityInterface
+public interface feature extends Feature, SimpleWorkflow {
+  @ActivityMethod
+  String echo();
+
+  class Impl implements feature {
+    @Override
+    public void workflow() {
+      // Allow 4 retries with no backoff
+      var activities =
+          activities(
+              feature.class, builder -> builder.setStartToCloseTimeout(Duration.ofMinutes(1)));
+
+      // Execute activity
+      activities.echo();
+    }
+
+    @Override
+    public String echo() {
+      return "hi";
+    }
+  }
+
+  @Override
+  default void workflowOptions(WorkflowOptions.Builder builder) {
+    builder.setWorkflowExecutionTimeout(Duration.ZERO);
+  }
+}

--- a/features/activity/basic_no_workflow_timeout/feature.py
+++ b/features/activity/basic_no_workflow_timeout/feature.py
@@ -9,6 +9,10 @@ from harness.python.feature import register_feature
 class Workflow:
     @workflow.run
     async def run(self) -> str:
+        await workflow.execute_activity(
+            echo,
+            schedule_to_close_timeout=timedelta(minutes=1),
+        )
         return await workflow.execute_activity(
             echo,
             start_to_close_timeout=timedelta(minutes=1),

--- a/features/activity/basic_no_workflow_timeout/feature.py
+++ b/features/activity/basic_no_workflow_timeout/feature.py
@@ -1,0 +1,28 @@
+from datetime import timedelta
+
+from temporalio import activity, workflow
+
+from harness.python.feature import register_feature
+
+
+@workflow.defn
+class Workflow:
+    @workflow.run
+    async def run(self) -> str:
+        return await workflow.execute_activity(
+            echo,
+            start_to_close_timeout=timedelta(minutes=1),
+        )
+
+
+@activity.defn
+async def echo() -> str:
+    return "echo"
+
+
+register_feature(
+    workflows=[Workflow],
+    activities=[echo],
+    expect_activity_error="activity attempt 5 failed",
+    start_options={"execution_timeout": None},
+)

--- a/features/activity/basic_no_workflow_timeout/feature.ts
+++ b/features/activity/basic_no_workflow_timeout/feature.ts
@@ -1,0 +1,22 @@
+import { Feature } from '@temporalio/harness';
+import * as wf from '@temporalio/workflow';
+
+const activities = wf.proxyActivities<typeof activitiesImpl>({
+  startToCloseTimeout: '1 minute',
+});
+
+export async function workflow(): Promise<string> {
+  return await activities.echo('hello');
+}
+
+const activitiesImpl = {
+  async echo(input: string): Promise<string> {
+    return input;
+  },
+};
+
+export const feature = new Feature({
+  workflow,
+  workflowStartOptions: { workflowExecutionTimeout: undefined },
+  activities: activitiesImpl,
+});

--- a/features/activity/basic_no_workflow_timeout/feature.ts
+++ b/features/activity/basic_no_workflow_timeout/feature.ts
@@ -5,7 +5,7 @@ const activities = wf.proxyActivities<typeof activitiesImpl>({
   startToCloseTimeout: '1 minute',
 });
 const activitiesSched2Close = wf.proxyActivities<typeof activitiesImpl>({
-   scheduleToCloseTimeout: '1 minute',
+  scheduleToCloseTimeout: '1 minute',
 });
 
 export async function workflow(): Promise<string> {

--- a/features/activity/basic_no_workflow_timeout/feature.ts
+++ b/features/activity/basic_no_workflow_timeout/feature.ts
@@ -4,8 +4,12 @@ import * as wf from '@temporalio/workflow';
 const activities = wf.proxyActivities<typeof activitiesImpl>({
   startToCloseTimeout: '1 minute',
 });
+const activitiesSched2Close = wf.proxyActivities<typeof activitiesImpl>({
+   scheduleToCloseTimeout: '1 minute',
+});
 
 export async function workflow(): Promise<string> {
+  await activitiesSched2Close.echo('hello');
   return await activities.echo('hello');
 }
 

--- a/features/eager_workflow/successful_start/feature.go
+++ b/features/eager_workflow/successful_start/feature.go
@@ -18,9 +18,12 @@ const expectedResult = "Hello World"
 var numEagerlyStarted atomic.Uint64
 
 var Feature = harness.Feature{
-	Workflows:            Workflow,
-	StartWorkflowOptions: client.StartWorkflowOptions{EnableEagerStart: true, WorkflowTaskTimeout: 1 * time.Hour},
-	CheckResult:          CheckResult,
+	Workflows: Workflow,
+	StartWorkflowOptionsMutator: func(o *client.StartWorkflowOptions) {
+		o.EnableEagerStart = true
+		o.WorkflowTaskTimeout = 1 * time.Hour
+	},
+	CheckResult: CheckResult,
 	ClientOptions: client.Options{
 		ConnectionOptions: client.ConnectionOptions{
 			DialOptions: []grpc.DialOption{grpc.WithUnaryInterceptor(EagerDetector(&numEagerlyStarted))},

--- a/features/features.go
+++ b/features/features.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	activity_basic_no_workflow_timeout "github.com/temporalio/features/features/activity/basic_no_workflow_timeout"
 	activity_cancel_try_cancel "github.com/temporalio/features/features/activity/cancel_try_cancel"
 	activity_retry_on_error "github.com/temporalio/features/features/activity/retry_on_error"
 	bugs_go_activity_start_race "github.com/temporalio/features/features/bugs/go/activity_start_race"
@@ -52,6 +53,7 @@ import (
 func init() {
 	// Please keep list in alphabetical order
 	harness.MustRegisterFeatures(
+		activity_basic_no_workflow_timeout.Feature,
 		activity_cancel_try_cancel.Feature,
 		activity_retry_on_error.Feature,
 		bugs_go_activity_start_race.Feature,

--- a/features/schedule/cron/feature.go
+++ b/features/schedule/cron/feature.go
@@ -13,9 +13,11 @@ import (
 )
 
 var Feature = harness.Feature{
-	Workflows:            Workflow,
-	StartWorkflowOptions: client.StartWorkflowOptions{CronSchedule: "@every 2s"},
-	CheckResult:          CheckResult,
+	Workflows: Workflow,
+	StartWorkflowOptionsMutator: func(o *client.StartWorkflowOptions) {
+		o.CronSchedule = "@every 2s"
+	},
+	CheckResult: CheckResult,
 	// Disable history check because we can't guarantee cron execution times
 	CheckHistory: harness.NoHistoryCheck,
 }

--- a/features/update/self/feature.go
+++ b/features/update/self/feature.go
@@ -33,13 +33,11 @@ var Feature = harness.Feature{
 		if reason := updateutil.CheckServerSupportsUpdate(ctx, runner.Client); reason != "" {
 			return nil, runner.Skip(reason)
 		}
-		opts := runner.Feature.StartWorkflowOptions
-		if opts.TaskQueue == "" {
-			opts.TaskQueue = runner.TaskQueue
+		opts := client.StartWorkflowOptions{
+			TaskQueue:                runner.TaskQueue,
+			WorkflowExecutionTimeout: 1 * time.Minute,
 		}
-		if opts.WorkflowExecutionTimeout == 0 {
-			opts.WorkflowExecutionTimeout = 1 * time.Minute
-		}
+		runner.Feature.StartWorkflowOptionsMutator(&opts)
 		return runner.Client.ExecuteWorkflow(ctx, opts, SelfUpdateWorkflow, ConnMaterial{
 			HostPort:       runner.Feature.ClientOptions.HostPort,
 			Namespace:      runner.Feature.ClientOptions.Namespace,

--- a/harness/go/cmd/run.go
+++ b/harness/go/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"go.temporal.io/sdk/client"
 	"io"
 	"net"
 	"net/url"
@@ -202,6 +203,10 @@ func (r *Runner) Run(ctx context.Context, run *Run) error {
 				sumEntry.Message = feature.SkipReason
 				r.log.Warn("Skipping feature", "Feature", feature.Dir, "Reason", feature.SkipReason)
 				return nil
+			}
+
+			if feature.StartWorkflowOptionsMutator == nil {
+				feature.StartWorkflowOptionsMutator = func(opts *client.StartWorkflowOptions) {}
 			}
 
 			runnerConfig := harness.RunnerConfig{

--- a/harness/go/harness/feature.go
+++ b/harness/go/harness/feature.go
@@ -41,16 +41,16 @@ type Feature struct {
 	// overridden internally.
 	ClientOptions client.Options
 
-	// Worker options for worker creation. Some values like WorkflowPanicPolicy
-	// are always overridden internally.
+	// Worker options for worker creation. Some values like WorkflowPanicPolicy are always
+	// overridden internally. By default, the harness sets the WorkflowPanicPolicy to FailWorkflow -
+	// in order to set that one option here you must *also* set the
+	// DisableWorkflowPanicPolicyOverride field to true.
 	WorkerOptions worker.Options
 
-	// Start workflow options that are used by the default executor. Some values
-	// such as task queue and workflow execution timeout, are set by default if
-	// not already set. By default the harness sets the WorkflowPanicPolicy to
-	// FailWorkflow - in order to set that one option here you must *also* set the
-	// DisableWorkflowPanicPolicyOverride field to true.
-	StartWorkflowOptions client.StartWorkflowOptions
+	// Can modify the workflow options that are used by the default executor. Some values such as
+	// task queue and workflow execution timeout, are set by default (but may be overridden by this
+	// mutator).
+	StartWorkflowOptionsMutator func(*client.StartWorkflowOptions)
 
 	// The harness will override the WorkflowPanicPolicy to be FailWorkflow
 	// unless this field is set to true, in which case the WorkflowPanicPolicy

--- a/harness/go/harness/runner.go
+++ b/harness/go/harness/runner.go
@@ -149,13 +149,11 @@ func (r *Runner) Run(ctx context.Context) error {
 // ExecuteDefault is the default execution that just runs the first workflow and
 // assumes it takes no parameters.
 func (r *Runner) ExecuteDefault(ctx context.Context) (client.WorkflowRun, error) {
-	opts := r.Feature.StartWorkflowOptions
-	if opts.TaskQueue == "" {
-		opts.TaskQueue = r.TaskQueue
+	opts := client.StartWorkflowOptions{
+		TaskQueue:                r.TaskQueue,
+		WorkflowExecutionTimeout: 1 * time.Minute,
 	}
-	if opts.WorkflowExecutionTimeout == 0 {
-		opts.WorkflowExecutionTimeout = 1 * time.Minute
-	}
+	r.Feature.StartWorkflowOptionsMutator(&opts)
 	firstWorkflow, err := r.Feature.GetPrimaryWorkflow()
 	if err != nil {
 		return nil, err

--- a/harness/go/harness/util.go
+++ b/harness/go/harness/util.go
@@ -45,13 +45,11 @@ func FindEvent(history client.HistoryEventIterator, cond func(*historypb.History
 // ExecuteWithArgs runs a workflow with default arguments
 func ExecuteWithArgs(workflow interface{}, args ...interface{}) func(ctx context.Context, r *Runner) (client.WorkflowRun, error) {
 	return func(ctx context.Context, r *Runner) (client.WorkflowRun, error) {
-		opts := r.Feature.StartWorkflowOptions
-		if opts.TaskQueue == "" {
-			opts.TaskQueue = r.TaskQueue
+		opts := client.StartWorkflowOptions{
+			TaskQueue:                r.TaskQueue,
+			WorkflowExecutionTimeout: 1 * time.Minute,
 		}
-		if opts.WorkflowExecutionTimeout == 0 {
-			opts.WorkflowExecutionTimeout = 1 * time.Minute
-		}
+		r.Feature.StartWorkflowOptionsMutator(&opts)
 		return r.Client.ExecuteWorkflow(ctx, opts, workflow, args...)
 	}
 }

--- a/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
+++ b/harness/java/io/temporal/sdkfeatures/PreparedFeature.java
@@ -6,6 +6,7 @@ public class PreparedFeature {
 
   static PreparedFeature[] ALL =
       PreparedFeature.prepareFeatures(
+          activity.basic_no_workflow_timeout.feature.Impl.class,
           activity.retry_on_error.feature.Impl.class,
           activity.cancel_try_cancel.feature.Impl.class,
           child_workflow.result.feature.Impl.class,

--- a/harness/ts/main.ts
+++ b/harness/ts/main.ts
@@ -1,5 +1,5 @@
 import { FeatureSource, Runner } from './harness';
-import { Runtime, DefaultLogger, makeTelemetryFilterString } from '@temporalio/worker';
+import { Runtime, DefaultLogger } from '@temporalio/worker';
 import pkg from '@temporalio/worker/lib/pkg';
 import { Command } from 'commander';
 import * as path from 'path';

--- a/harness/ts/main.ts
+++ b/harness/ts/main.ts
@@ -1,5 +1,5 @@
 import { FeatureSource, Runner } from './harness';
-import { Runtime, DefaultLogger } from '@temporalio/worker';
+import { Runtime, DefaultLogger, makeTelemetryFilterString } from '@temporalio/worker';
 import pkg from '@temporalio/worker/lib/pkg';
 import { Command } from 'commander';
 import * as path from 'path';


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added test that catches the issue that caused an incident recently and was resolved by https://github.com/temporalio/temporal/pull/5445

The reason this wasn't caught before is because when a workflow execution timeout is set, that gets propagated by server to any un-set activity timeouts.

## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/features/issues/421

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
