### PR TITLE
Replace docker-compose with docker compose

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Start containerized server and dependencies
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
@@ -100,11 +100,11 @@ jobs:
       - name: Run containerized SDK-features tests
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-cs features-tests-cs
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v
+        run: docker compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Start containerized server and dependencies
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
@@ -84,11 +84,11 @@ jobs:
         env:
           WAIT_EXTRA_FOR_NAMESPACE: true
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-go features-tests-go
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v
+        run: docker compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Start containerized server and dependencies
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
@@ -88,11 +88,11 @@ jobs:
       - name: Run containerized SDK-features tests
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-java features-tests-java
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v
+        run: docker compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Start containerized server and dependencies
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
@@ -107,11 +107,11 @@ jobs:
       - name: Run containerized SDK-features tests
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-py features-tests-py
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v
+        run: docker compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: Start containerized server and dependencies
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up -d temporal-server cassandra elasticsearch
@@ -107,11 +107,11 @@ jobs:
       - name: Run containerized SDK-features tests
         if: inputs.docker-image-artifact-name
         run: |
-          docker-compose \
+          docker compose \
             -f ./dockerfiles/docker-compose.for-server-image.yaml \
             -f /tmp/server-docker/docker-compose.yml \
             up --no-log-prefix --exit-code-from features-tests-ts features-tests-ts
 
       - name: Tear down docker compose
         if: inputs.docker-image-artifact-name && (success() || failure())
-        run: docker-compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v
+        run: docker compose -f ./dockerfiles/docker-compose.for-server-image.yaml -f /tmp/server-docker/docker-compose.yml down -v


### PR DESCRIPTION
## What was changed

`docker-compose` has been replaced with `docker compose`

## Why?

Docker seems to have deprecated it, which is causing build pipelines which use new versions of docker (or the runner image, I didn't investigate) to fail.