### PR TITLE
Bump GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
 
@@ -48,8 +48,8 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
 
       - run: npm ci
       - run: npm run build
@@ -64,8 +64,8 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade wheel poetry poethepoet
@@ -81,10 +81,10 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -100,8 +100,8 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
       - run: dotnet build
       - run: dotnet test
 

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -45,8 +45,8 @@ jobs:
         run: exit 1
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
       - name: Lint dockerfile

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
@@ -58,36 +58,37 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
       - name: Checkout .NET SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.dotnet-repo-path }}
           submodules: recursive
           path: sdk-dotnet
           ref: ${{ inputs.version }}
 
-      - uses: actions/setup-dotnet@v3
+      - uses: actions/setup-dotnet@v4
 
       - name: Install protoc
         if: ${{ inputs.version-is-repo-ref }}
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.version-is-repo-ref }}
         with:
-          working-directory: sdk-dotnet/src/Temporalio/Bridge
+          workspaces: sdk-dotnet/src/Temporalio/Bridge
 
       # Build .NET SDK if using repo
       # Don't build during install phase since we're going to explicitly build

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
@@ -58,7 +58,7 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
@@ -66,14 +66,14 @@ jobs:
 
       - name: Checkout Go SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.go-repo-path }}
           submodules: recursive
           path: sdk-go
           ref: ${{ inputs.version }}
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
@@ -59,14 +59,14 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
           fetch-depth: 0
       - name: Checkout Java SDK repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ inputs.version-is-repo-ref }}
         with:
           repository: ${{ inputs.java-repo-path }}
@@ -75,11 +75,11 @@ jobs:
           ref: ${{ inputs.version }}
           fetch-depth: 0
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
@@ -58,24 +58,24 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
       - name: Checkout Python SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.python-repo-path }}
           submodules: recursive
           path: sdk-python
           ref: ${{ inputs.version }}
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - run: python -m pip install --upgrade wheel poetry poethepoet
@@ -83,14 +83,15 @@ jobs:
       # Build SDK ==================================================
       - name: Install Protoc
         if: ${{ inputs.version-is-repo-ref }}
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.version-is-repo-ref }}
         with:
-          working-directory: sdk-python/temporalio/bridge
+          workspaces: sdk-python/temporalio/bridge
       - run: poetry install --no-root
         if: ${{ inputs.version-is-repo-ref }}
         working-directory: sdk-python

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
@@ -58,38 +58,39 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
       - name: Checkout typescript SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ inputs.typescript-repo-path }}
           submodules: recursive
           path: sdk-ts
           ref: ${{ inputs.version }}
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: Install protoc
         if: ${{ inputs.version-is-repo-ref }}
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          # TODO: Upgrade proto once https://github.com/arduino/setup-protoc/issues/99 is fixed
+          version: '23.x'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.20'
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.version-is-repo-ref }}
         with:
-          working-directory: sdk-ts/packages/core-bridge
+          workspaces: sdk-ts/packages/core-bridge
 
       # Build TS SDK if using repo
       # Don't build during install phase since we're going to explicitly build


### PR DESCRIPTION
## What was changed

- Updated all GHA actions to latest.

## Why?

- GitHub is pulling the plug on `upload-artifact@v2` on June 30th;
- All GHA actions based on Node 16 are deprecated.