### PR TITLE
Don't use class attributes for mutable workflow state

### DIFF
--- a/features/update/basic/feature.py
+++ b/features/update/basic/feature.py
@@ -9,7 +9,8 @@ from harness.python.feature import Runner, register_feature
 
 @workflow.defn
 class Workflow:
-    am_done = False
+    def __init__(self) -> None:
+        self.am_done = False
 
     @workflow.run
     async def run(self) -> str:

--- a/features/update/self/feature.py
+++ b/features/update/self/feature.py
@@ -9,7 +9,8 @@ from harness.python.feature import Runner, register_feature
 
 @workflow.defn
 class Workflow:
-    am_done = False
+    def __init__(self) -> None:
+        self.am_done = False
 
     @workflow.run
     async def run(self) -> str:

--- a/features/update/task_failure/feature.py
+++ b/features/update/task_failure/feature.py
@@ -12,7 +12,8 @@ task_fails_counter = 0
 
 @workflow.defn
 class Workflow:
-    am_done = False
+    def __init__(self) -> None:
+        self.am_done = False
 
     @workflow.run
     async def run(self) -> str:

--- a/features/update/validation_replay/feature.py
+++ b/features/update/validation_replay/feature.py
@@ -13,7 +13,8 @@ task_fails_counter = 0
 
 @workflow.defn
 class Workflow:
-    am_done = False
+    def __init__(self) -> None:
+        self.am_done = False
 
     @workflow.run
     async def run(self) -> str:


### PR DESCRIPTION
We should not use class attributes for mutable workflow state since they are shared between workflow instances within the same worker process. Even if multiple concurrent instances are unlikely in these examples, this repo may be used by users as a source of code examples.