### PR TITLE
Update Java Dockerfile to Ubuntu Noble

### DIFF
--- a/dockerfiles/java.Dockerfile
+++ b/dockerfiles/java.Dockerfile
@@ -5,7 +5,7 @@ FROM eclipse-temurin:11 as build
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.12.4* git=1:2.34.1-1ubuntu1
+      protobuf-compiler=3.21.12* git=1:2.43.0*
 
 ARG PLATFORM=amd64
 RUN wget -q https://go.dev/dl/go1.21.11.linux-${PLATFORM}.tar.gz \


### PR DESCRIPTION
## What was changed

- Updated Java Dockerfile's dependency versions to correspond to those of Ubuntu Noble (24.04).

## Why?

- The upstream `eclipse-temurin:11` image, which we use as base image for our Java Dockerfile, has just updated their own base image.
