### PR TITLE
Make Java async accepted test more forgiving

### DIFF
--- a/features/update/async_accepted/feature.java
+++ b/features/update/async_accepted/feature.java
@@ -108,8 +108,8 @@ public interface feature extends Feature, SimpleWorkflow {
         if (e instanceof ExecutionException) {
           e = e.getCause();
         }
-        Assertions.assertTrue(e.getCause() instanceof WorkflowUpdateException);
-        WorkflowUpdateException wue = (WorkflowUpdateException) e.getCause();
+        Assertions.assertTrue(e instanceof WorkflowUpdateException);
+        WorkflowUpdateException wue = (WorkflowUpdateException) e;
         Assertions.assertTrue(wue.getCause() instanceof ApplicationFailure);
         Assertions.assertEquals("Failure", ((ApplicationFailure) wue.getCause()).getType());
         Assertions.assertEquals(


### PR DESCRIPTION
@alexshtin Noticed the Java SDKs `startUpdate` API behaved differently then other SDK APIs where `startUpdate` with a wait stage of accepted may throw an exception even if the update is accepted (currently if it does or not just depends on a race in the server AFAIK). I consider this a bug in the Java SDK implementation, and should be fixed. For now making the test slightly more permissive to avoid blocking any server work.
