### PR TITLE
Add Ruby to list of SDKs in epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -27,5 +27,6 @@ assignees: ''
 - [ ] TypeScript - 
 - [ ] Python - 
 - [ ] .NET - 
+- [ ] Ruby - 
 - [ ] PHP - 
 - [ ] Temporal CLI - 


### PR DESCRIPTION
## What was changed

Add Ruby to list of SDKs in epic issue template. Ruby is at the place where we need to include it for any new features.