### PR TITLE
Disable versioning tests

### DIFF
--- a/features/build_id_versioning/common.go
+++ b/features/build_id_versioning/common.go
@@ -3,6 +3,8 @@ package build_id_versioning
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/temporalio/features/harness/go/harness"
@@ -40,6 +42,14 @@ func AddSomeVersions(ctx context.Context, c client.Client, tq string) error {
 }
 
 func ServerSupportsBuildIDVersioning(ctx context.Context, r *harness.Runner) (bool, error) {
+	// Force to explicitly enable these old tests since they fail in Server 1.25+.
+	// This versioning API has been deprecated, and tests need to be rewritten for
+	// the new API.
+	enable, present := os.LookupEnv("ENABLE_VERSIONING_TESTS")
+	if !present || strings.ToLower(enable) != "true" {
+		return false, nil
+	}
+
 	capabilities, err := r.Client.WorkflowService().GetSystemInfo(ctx, &workflowservice.GetSystemInfoRequest{})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
The deprecated v1 versioning tests fail in the latest 1.25+ server. These tests need to
be rewritten to use the latest versioning API, once that API stabilizes. This is currently
blocking a new server production test that runs features as a sanity check.

This PR disables them for now, until the rewrite, or a fix for 1.25+. For debugging they can be enabled with the 
environment property `ENABLE_VERSIONING_TESTS=true`
