### PR TITLE
Centralize dynamic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Publishing docker images of the features runner/suites is also supported. It may
 [manually](https://github.com/temporalio/features/actions/workflows/all-docker-images.yaml),
 but is also triggered by default on each push to main.
 
+The dynamic configuration file located at `dockerfiles/dynamicconfig/docker.yaml` defines the dynamic configuration
+settings needed for features to run, and should be used as part of or all of the dynamic config settings for any
+external server not using the basic docker-compose setup.
+
 ## TODO
 
 - Add support for replaying testing of all versions _inside_ each SDKs harness as part of the run

--- a/dockerfiles/dynamicconfig/docker.yaml
+++ b/dockerfiles/dynamicconfig/docker.yaml
@@ -1,3 +1,12 @@
+frontend.forceSearchAttributesCacheRefreshOnRead:
+  - value: true
+    constraints: {}
+frontend.enableActivityEagerExecution:
+  - value: true
+    constraints: {}
+frontend.enableEagerWorkflowStart:
+  - value: true
+    constraints: {}
 frontend.enableUpdateWorkflowExecution:
   - value: true
     constraints: {}


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Read dynamic config from a central location

## Why?
Makes it easier for users of the repo in full-on environments like k8s have a file they can just grab and use for server dynamic config.

## Checklist
<!--- add/delete as needed --->

1. Closes https://github.com/temporalio/features/issues/529

2. How was this tested:
Existing features work that need these features enabled

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
