### PR TITLE
Build docker images on all main CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,7 +205,7 @@ jobs:
     uses: ./.github/workflows/all-docker-images.yaml
     secrets: inherit
     with:
-      do-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      do-push: ${{ github.ref == 'refs/heads/main' }}
       go-ver: 'v${{ needs.build-go.outputs.go_latest }}'
       ts-ver: 'v${{ needs.build-go.outputs.typescript_latest }}'
       java-ver: 'v${{ needs.build-go.outputs.java_latest }}'


### PR DESCRIPTION
## Why?

Allow any build of the main branch to push images to dockerhub to generate images on demand without requiring changes to this repo.