### PR TITLE
Fix python version constraint

### DIFF
--- a/sdkbuild/python.go
+++ b/sdkbuild/python.go
@@ -126,7 +126,7 @@ description = "Temporal SDK Python Test"
 authors = ["Temporal Technologies Inc <sdk@temporal.io>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.10"
 temporalio = ` + versionStr + `
 ` + options.DependencyName + ` = { path = "../" }
 


### PR DESCRIPTION
The python harness is not compatible with 3.8 since it uses an unsupported dict union syntax. Tightening constraint to `^3.10`.