### PR TITLE
PHP: fix a floating error in the worker_restart feature check

### DIFF
--- a/features/update/worker_restart/feature.php
+++ b/features/update/worker_restart/feature.php
@@ -13,7 +13,6 @@ use Temporal\Activity\ActivityInterface;
 use Temporal\Activity\ActivityMethod;
 use Temporal\Activity\ActivityOptions;
 use Temporal\Client\WorkflowStubInterface;
-use Temporal\Exception\Failure\ApplicationFailure;
 use Temporal\Workflow;
 use Temporal\Workflow\WorkflowInterface;
 use Temporal\Workflow\WorkflowMethod;
@@ -58,9 +57,8 @@ class FeatureActivity
         $this->kv->set(KV_ACTIVITY_STARTED, true);
 
         do {
-            $blocked = $this->kv->get(KV_ACTIVITY_BLOCKED);
+            $blocked = $this->kv->get(KV_ACTIVITY_BLOCKED, true);
 
-            \is_bool($blocked) or throw new ApplicationFailure('KV BLOCKED key not set', 'KvNotSet', true);
             if (!$blocked) {
                 break;
             }
@@ -80,7 +78,6 @@ class FeatureChecker
         ContainerInterface $c,
         Runner $runner,
     ): void {
-        $c->get(StorageInterface::class)->set(KV_ACTIVITY_BLOCKED, true);
         $handle = $stub->startUpdate('do_activities');
 
         # Wait for the activity to start.


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

Same changes as [here](https://github.com/temporalio/sdk-php/pull/542)

## Why?
<!-- Tell your future self why have you made these changes -->
To make the worker_restart check stable

