### PR TITLE
Don't rely on TS FailureConverter returning a TemporalFailure

### DIFF
--- a/dockerfiles/go.Dockerfile
+++ b/dockerfiles/go.Dockerfile
@@ -1,5 +1,5 @@
 # Build in a full featured container
-FROM golang:1.21 as build
+FROM golang:1.23 as build
 
 WORKDIR /app
 

--- a/features/activity/retry_on_error/feature.ts
+++ b/features/activity/retry_on_error/feature.ts
@@ -1,6 +1,7 @@
 import { Context } from '@temporalio/activity';
 import * as wf from '@temporalio/workflow';
 import { WorkflowFailedError } from '@temporalio/client';
+import { TemporalFailure } from '@temporalio/common';
 import { Feature } from '@temporalio/harness';
 import * as assert from 'assert';
 
@@ -37,7 +38,8 @@ export const feature = new Feature({
         err instanceof WorkflowFailedError,
         `expected WorkflowFailedError, got ${typeof err}, message: ${(err as any).message}`
       );
-      assert.equal(err.cause?.cause?.message, 'activity attempt 5 failed');
+      assert.ok(err.cause instanceof TemporalFailure);
+      assert.equal(err.cause.cause?.message, 'activity attempt 5 failed');
       return true;
     });
   },


### PR DESCRIPTION
See related change: https://github.com/temporalio/sdk-typescript/pull/1685

Also upgraded Go in docker image to ensure the Go image build action passes.