### PR TITLE
Pin protobufjs to 7.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@temporalio/workflow": "^1.11.1",
         "commander": "^8.3.0",
         "ms": "^3.0.0-canary.1",
-        "proto3-json-serializer": "^1.1.1"
+        "proto3-json-serializer": "^1.1.1",
+        "protobufjs": "7.5.1"
       },
       "devDependencies": {
         "@tsconfig/node16": "^1.0.0",
@@ -2744,10 +2745,11 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
+      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -5655,9 +5657,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.1.tgz",
+      "integrity": "sha512-3qx3IRjR9WPQKagdwrKjO3Gu8RgQR2qqw+1KnigWhoVjFqegIj1K3bP11sGqhxrO46/XL7lekuG4jmjL+4cLsw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@temporalio/proto": "^1.11.1",
     "@temporalio/worker": "^1.11.1",
     "@temporalio/workflow": "^1.11.1",
+    "protobufjs": "7.5.1",
     "commander": "^8.3.0",
     "ms": "^3.0.0-canary.1",
     "proto3-json-serializer": "^1.1.1"

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -105,8 +105,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
 		if err != nil {
 			return nil, fmt.Errorf("cannot get absolute path from version path: %w", err)
 		}
-		pkgs := []string{"activity", "client", "common", "internal-workflow-common",
-			"internal-non-workflow-common", "proto", "worker", "workflow"}
+		pkgs := []string{"activity", "client", "common", "proto", "worker", "workflow"}
 		for _, pkg := range pkgs {
 			pkgPath := "file:" + filepath.Join(localPath, "packages", pkg)
 			packageJSONDepStr += fmt.Sprintf(`"@temporalio/%v": %q,`, pkg, pkgPath)
@@ -146,7 +145,8 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
     "typescript": "^4.4.2"
   },
   "overrides": {
-        "@grpc/grpc-js" : "1.10.10"
+        "@grpc/grpc-js" : "1.10.10",
+		"protobufjs": "7.5.1"
   }
 }`
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(packageJSON), 0644); err != nil {


### PR DESCRIPTION
## What was changed

Pin TS `protobufjs` to 7.5.1.

## Why?

`protobufjs` 7.5.2, released yesterday, appears to be causing some frictions with an internal mechanism of the SDK, which is results in failure of feature tests related to the TS SDK Protobuf Payload Converter feature.

Due to technical constraints of our feature test harness, our feature tests reuse some protobuf message definitions of the SDK itself, rather than defining and compiling their own protobuf messages as one would normally do. SDK's own tests for that same feature, which more closely represent what how a user would normally implement this, are still passing; same for our `protobufs` sample in a TS SDK 1.11.8 + protobufjs 7.5.2 setup.

For those reasons, temporarily silencing this issue seems a reasonable decision. The SDK itself will also pin the `protobufjs` dependency until we can properly investigate and resolve this issue (will be pinned in temporalio/sdk-typescript#1679, issue tracked in in temporalio/sdk-typescript#1717).