### PR TITLE
Fixed SDK version mismatch in .Net build. Made `--version` optional in `prepare`.

### DIFF
--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -44,7 +44,6 @@ func (p *PrepareConfig) flags() []cli.Flag {
 		&cli.StringFlag{
 			Name:        "version",
 			Usage:       "SDK language version to run. Most languages support versions as paths.",
-			Required:    true,
 			Destination: &p.Version,
 		},
 	}
@@ -73,8 +72,6 @@ func (p *Preparer) Prepare(ctx context.Context) error {
 		return fmt.Errorf("directory required")
 	} else if strings.ContainsAny(p.config.DirName, `\/`) {
 		return fmt.Errorf("directory must not have path separators, it is always relative to the SDK features root")
-	} else if p.config.Version == "" {
-		return fmt.Errorf("version required")
 	}
 
 	// Try to create dir or error if already exists.

--- a/cmd/run_dotnet.go
+++ b/cmd/run_dotnet.go
@@ -3,9 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
-
 	"github.com/temporalio/features/harness/go/cmd"
 	"github.com/temporalio/features/sdkbuild"
 )
@@ -15,29 +12,10 @@ import (
 // beneath the root directory.
 func (p *Preparer) BuildDotNetProgram(ctx context.Context) (sdkbuild.Program, error) {
 	p.log.Info("Building .NET project", "DirName", p.config.DirName)
-
-	// Get version from dotnet.csproj if not present
-	version := p.config.Version
-	if version == "" {
-		csprojBytes, err := os.ReadFile("dotnet.csproj")
-		if err != nil {
-			return nil, fmt.Errorf("failed reading dotnet.csproj: %w", err)
-		}
-		const prefix = `<PackageReference Include="Temporalio" Version="`
-		csproj := string(csprojBytes)
-		beginIndex := strings.Index(csproj, prefix)
-		if beginIndex == -1 {
-			return nil, fmt.Errorf("cannot find Temporal dependency in csproj")
-		}
-		beginIndex += len(prefix)
-		length := strings.Index(csproj[beginIndex:], `"`)
-		version = csproj[beginIndex : beginIndex+length]
-	}
-
 	prog, err := sdkbuild.BuildDotNetProgram(ctx, sdkbuild.BuildDotNetProgramOptions{
 		BaseDir:         p.rootDir,
 		DirName:         p.config.DirName,
-		Version:         version,
+		Version:         p.config.Version,
 		ProgramContents: `await Temporalio.Features.Harness.App.RunAsync(args);`,
 		CsprojContents: `<Project Sdk="Microsoft.NET.Sdk">
 			<PropertyGroup>

--- a/dotnet.csproj
+++ b/dotnet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" InitialTargets="CheckCommandLineProperties">
 
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -14,23 +14,35 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
+  <!-- Default SDK version if not specified in command line -->
+  <PropertyGroup Condition="'$(TemporalioVersion)' == '' And '$(TemporalioProjectReference)' == ''">
+    <TemporalioVersion>1.6.0</TemporalioVersion>
+  </PropertyGroup>
+
+  <Target Name="CheckCommandLineProperties">
+    <Error
+      Condition="'$(TemporalioVersion)' != '' And '$(TemporalioProjectReference)' != ''"
+      Text="TemporalioVersion and TemporalioProjectReference properties are mutually exclusive." />
+  </Target>
+
   <ItemGroup>
     <Compile Include="features\**\*.cs" />
     <Compile Include="harness\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="Temporalio" Version="1.3.1">
-      <!--
-        We have to make sure this isn't included transitively so it can be
-        overridden.
-      -->
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="XUnit.Assert" Version="2.5.3" />
+    <PackageReference Include="XUnit.Assert" Version="2.6.6" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TemporalioVersion)' != ''">
+    <PackageReference Include="Temporalio" Version="$(TemporalioVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TemporalioProjectReference)' != ''">
+    <ProjectReference Include="$(TemporalioProjectReference)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
- Changed .Net build files so that the tests are built against the same Temporal SDK version they're being run with.
- Made `--version` argument optional in `temporal-features prepare` command.

## Why?
<!-- Tell your future self why have you made these changes -->
- Previously, .Net harness and tests were built against the hardcoded SDK version but run with the version specified in command line. This would make the code sometimes fail mysteriously due to binary incompatibilities, and caused CI failure in sdk-dotnet PR: https://github.com/temporalio/sdk-dotnet/pull/483/ . Now, the harness and tests are always built and run with the same SDK version.

- `run` command already supported omitting `--version` argument (individual languages still do a check if it's required for them). `prepare` still had it as always required for no real reason, so I changed it to match `run`'s behavior to make testing the other fix easier. This change seems useful in general, so I left it in.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
- Before, .Net feature tests failed with MissingMethodException if tested with SDK commit https://github.com/temporalio/sdk-dotnet/pull/483/commits/ab26dfe8337f36be3d9fb698f3826f822248251d . After these changes, the tests pass.

- `temporal-features prepare` with omitted/default version was tested to work correctly with Java, Go and .Net.