### PR TITLE
Fix flake in timeout_due_to_no_active_workers on TypeScript

### DIFF
--- a/harness/ts/harness.ts
+++ b/harness/ts/harness.ts
@@ -163,6 +163,7 @@ export class Runner<W extends Workflow, A extends UntypedActivities> {
             },
           };
         },
+        ignoreModules: ['@grpc/grpc-js'],
       },
       interceptors: {
         activityInbound: [() => new ConnectionInjectorInterceptor(connection, client)],


### PR DESCRIPTION
## What was changed

- Fix a [flake](https://github.com/temporalio/temporal/actions/runs/15935788831/job/44955315944?pr=7978#step:16:441) in `timeout_due_to_no_active_workers` on TypeScript, that has apparently been observed a few times recently by our server devs.

  It is unclear why this flake is appearing now and not before, and has only been observed by them, not in this repo's or TS SDK's recent runs, so there might be some recent server side change involved.

  In any case, Python and PHP already accepted either `CANCELED` and `DEADLINE_EXCEEDED` error code in that same test, and that seems the right thing to do, as a grpc server [is allowed to time out a request early](https://grpc.io/docs/guides/deadlines/#deadlines-on-the-server) with `CANCELLED` (i.e. before the client itself times out with `DEADLINE_EXCEEDED`) if it deems that the time remaining before the deadline is insufficient to successfully complete the request.