### PR TITLE
Update Rust to at least 1.88

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -88,8 +88,6 @@ jobs:
           go-version: '^1.21'
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.version-is-repo-ref }}

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -89,8 +89,6 @@ jobs:
           go-version: '^1.21'
 
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.88.0
 
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.version-is-repo-ref }}


### PR DESCRIPTION
## What was changed

- Upgrade Rust to at least 1.88.0 in TypeScript and .Net. This is required by recent changes in Core. Python has already been updated in #640.