### PR TITLE
Add missing TS dependency to @grpc/grpc-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "features",
       "dependencies": {
+        "@grpc/grpc-js": "^1.12.4",
         "@protobuf-ts/protoc": "^2.8.1",
         "@temporalio/activity": "^1.11.8",
         "@temporalio/client": "^1.11.8",
@@ -219,9 +220,10 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
-      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -3908,9 +3910,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
-      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.4.tgz",
+      "integrity": "sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==",
       "requires": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "ts-node -r tsconfig-paths/register harness/ts/main.ts"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.12.4",
     "@protobuf-ts/protoc": "^2.8.1",
     "@temporalio/activity": "^1.11.8",
     "@temporalio/client": "^1.11.8",

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -132,6 +132,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
   "dependencies": {
     ` + packageJSONDepStr + `
 	` + moreDeps + `
+    "@grpc/grpc-js": "^1.12.4",
     "commander": "^8.3.0",
     "ms": "^3.0.0-canary.1",
     "proto3-json-serializer": "^1.1.1",


### PR DESCRIPTION
## What was changed

- Added a missing TS dependency to `@grpc/grpc-js`. I added an import to that package in one test in #641, which is working properly when running `features` tests directly (e.g. including `features`' own CI workflows). It is however not working when tests are being run from the TS repo, hence this PR.