### PR TITLE
Move TS docker to node20

### DIFF
--- a/dockerfiles/ts.Dockerfile
+++ b/dockerfiles/ts.Dockerfile
@@ -2,7 +2,7 @@
 # The author (git blame to reveal) prefers some copying over templating the Dockerfiles.
 
 # Build in a full featured container
-FROM node:16 as build
+FROM node:20 as build
 
 # Install protobuf compiler
 RUN apt-get update \
@@ -45,7 +45,7 @@ COPY ./${REPO_DIR_OR_PLACEHOLDER} ./${REPO_DIR_OR_PLACEHOLDER}
 RUN CGO_ENABLED=0 ./temporal-features prepare --lang ts --dir prepared --version "$SDK_VERSION"
 
 # Copy the CLI and prepared feature to a distroless "run" container
-FROM gcr.io/distroless/nodejs:16
+FROM gcr.io/distroless/nodejs20-debian11
 
 COPY --from=build /app/temporal-features /app/temporal-features
 COPY --from=build /app/features /app/features


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Bumped up node v from 16 to 20

## Why?
<!-- Tell your future self why have you made these changes -->
TS docker has been failing with `E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.`, move to newer node version


## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
