### PR TITLE
[TS] Fix the client injection activity interceptor conflicting with new upstream API

### DIFF
--- a/harness/ts/activity-interceptors.ts
+++ b/harness/ts/activity-interceptors.ts
@@ -2,12 +2,14 @@ import * as activity from '@temporalio/activity';
 import { Connection, Client } from '@temporalio/client';
 import { ActivityExecuteInput, ActivityInboundCallsInterceptor, Next } from '@temporalio/worker';
 
+// FIXME: Remove this interceptor once 1.12.4 has been released
+//        https://github.com/temporalio/sdk-typescript/pull/1769
 export class ConnectionInjectorInterceptor implements ActivityInboundCallsInterceptor {
   constructor(public readonly connection: Connection, public readonly client: Client) {}
   async execute(input: ActivityExecuteInput, next: Next<ActivityInboundCallsInterceptor, 'execute'>): Promise<unknown> {
     Object.assign(activity.Context.current(), {
-      connection: this.connection,
-      client: this.client,
+      injectedConnection: this.connection,
+      injectedClient: this.client,
     });
     return next(input);
   }
@@ -17,20 +19,20 @@ export class ConnectionInjectorInterceptor implements ActivityInboundCallsInterc
  * Extend the basic activity Context
  */
 export interface Context extends activity.Context {
-  connection: Connection;
-  client: Client;
+  injectedConnection: Connection;
+  injectedClient: Client;
 }
 
 /**
  * Get the client object associated with the current activity context
  */
 export function getClient(): Client {
-  return (activity.Context.current() as unknown as Context).client;
+  return (activity.Context.current() as unknown as Context).injectedClient;
 }
 
 /**
  * Get the connection object associated with the current activity context
  */
 export function getConnection(): Connection {
-  return (activity.Context.current() as unknown as Context).connection;
+  return (activity.Context.current() as unknown as Context).injectedConnection;
 }


### PR DESCRIPTION
## What was changed

- The TS SDK just added official support for passing a Client through activity's `Context`. Once that PR get released, it will remove the need for the `ConnectionInjectorInterceptor` used in Feature test harness.

  However, in the mean time, that interceptor is conflicting with the upstream API change, as the interceptor tries to modify the `Context.client` property, but that property is now non-writable.

  This PR temporarily resolve this error by changing the name of the property used by the interceptor.