### PR TITLE
Update TS Dockerfile to Node 22/Bullseye

### DIFF
--- a/dockerfiles/ts.Dockerfile
+++ b/dockerfiles/ts.Dockerfile
@@ -1,11 +1,10 @@
 # Build in a full featured container
 FROM node:22-bullseye AS build
 
-# Install protobuf compiler
 RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive \
+  && DEBIAN_FRONTEND=noninteractive \
     apt-get install --no-install-recommends --assume-yes \
-      protobuf-compiler=3.6.1.3-2* libprotobuf-dev=3.6.1.3-2*
+      protobuf-compiler=3.12.4* libprotobuf-dev=3.12.4*
 
 # Get go compiler
 ARG PLATFORM=amd64


### PR DESCRIPTION
## What was changed

- Update TS Dockerfile to Node 22 and Debian Bullseye

## Why?

- Dockerfile was previously using Node 16, which is no longer supported by the SDK.
- Also, Dockerfile was using an old release of Debian, which was now giving 404 errors while trying to install some required APT packages.