### PR TITLE
Handle if crt/key are Uint8Array

### DIFF
--- a/features/client/http_proxy/feature.ts
+++ b/features/client/http_proxy/feature.ts
@@ -37,9 +37,13 @@ export const feature = new Feature({
                 clientCertPair: {
                   // Can't serialize Buffers safely to JSON, so let's cheat a bit
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  crt: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.crt).toString('base64') as unknown as Buffer,
+                  crt: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.crt).toString(
+                    'base64'
+                  ) as unknown as Buffer,
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  key: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.key).toString('base64') as unknown as Buffer,
+                  key: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.key).toString(
+                    'base64'
+                  ) as unknown as Buffer,
                 },
               },
             }

--- a/features/client/http_proxy_auth/feature.ts
+++ b/features/client/http_proxy_auth/feature.ts
@@ -39,9 +39,13 @@ export const feature = new Feature({
                 clientCertPair: {
                   // Can't serialize Buffers safely to JSON, so let's cheat a bit
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  crt: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.crt).toString('base64') as unknown as Buffer,
+                  crt: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.crt).toString(
+                    'base64'
+                  ) as unknown as Buffer,
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                  key: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.key).toString('base64') as unknown as Buffer,
+                  key: Buffer.from(runner.connectionOpts.tls!.clientCertPair!.key).toString(
+                    'base64'
+                  ) as unknown as Buffer,
                 },
               },
             }


### PR DESCRIPTION
## What was changed
DWISOTT

## Why?
env config PR changes these types to Uint8Array

2. How was this tested:
`go run . run --lang ts`

3. Any docs updates needed?
No
