### PR TITLE
VLN-484: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/all-docker-images.yaml
+++ b/.github/workflows/all-docker-images.yaml
@@ -67,6 +67,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-go-docker-images:
     if: inputs.go-ver || inputs.go-repo-ref

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,9 @@ on: # rebuild any PRs and main branch changes
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -185,6 +188,9 @@ jobs:
       - run: dotnet test
 
   feature-tests-ts:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/typescript.yaml
     with:
@@ -194,6 +200,9 @@ jobs:
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-go:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/go.yaml
     with:
@@ -203,6 +212,9 @@ jobs:
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-python:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/python.yaml
     with:
@@ -212,6 +224,9 @@ jobs:
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-php:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/php.yaml
     with:
@@ -221,6 +236,9 @@ jobs:
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-java:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/java.yaml
     with:
@@ -230,6 +248,9 @@ jobs:
       features-repo-path: ${{ github.event.pull_request.head.repo.full_name }}
 
   feature-tests-dotnet:
+    permissions:
+      contents: read
+      actions: read
     needs: build-go
     uses: ./.github/workflows/dotnet.yaml
     with:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -31,6 +31,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-image:
     name: Build ${{ inputs.lang }} docker image

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -24,6 +24,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yaml`: Set workflow default to `contents: read` at ci.yaml:29 and added job-level `contents`/`actions` read permissions for reusable feature test calls at ci.yaml:190,203,215,227,239,251 to cover artifact downloads.
- `.github/workflows/docker-images.yaml`: Added workflow-level `contents: read` to lock down the default token while preserving checkout access at docker-images.yaml:34.
- `.github/workflows/dotnet.yaml`: Declared workflow-level `contents: read` and `actions: read` at dotnet.yaml:26 so artifact downloads and repo access work with least privilege.
- `.github/workflows/go.yaml`: Declared workflow-level `contents: read` and `actions: read` at go.yaml:26 to cover checkout and optional artifact retrieval.
- `.github/workflows/java.yaml`: Declared workflow-level `contents: read` and `actions: read` at java.yaml:27 for checkout plus artifact download support.
- `.github/workflows/php.yaml`: Declared workflow-level `contents: read` and `actions: read` at php.yaml:26 to scope the token while allowing artifact access when needed.
- `.github/workflows/python.yaml`: Declared workflow-level `contents: read` and `actions: read` at python.yaml:26 to cover checkout, protoc setup, and artifact download.
- `.github/workflows/typescript.yaml`: Declared workflow-level `contents: read` and `actions: read` at typescript.yaml:26 for checkout plus optional artifact usage.
- `.github/workflows/all-docker-images.yaml`: Added workflow-level `contents: read` at all-docker-images.yaml:70 so reusable image-build calls inherit explicit read-only defaults.