### PR TITLE
remove autosetup

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -45,7 +45,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -45,7 +45,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -46,7 +46,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -47,7 +47,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -45,7 +45,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -45,7 +45,7 @@ jobs:
           name: ${{ inputs.docker-image-artifact-name }}
           path: /tmp/server-docker
 
-      - name: Load server Docker images
+      - name: Load server Docker Images
         if: ${{ inputs.docker-image-artifact-name }}
         run: |
           docker load --input /tmp/server-docker/temporal-server.tar

--- a/dockerfiles/docker-compose.for-server-image.yaml
+++ b/dockerfiles/docker-compose.for-server-image.yaml
@@ -62,8 +62,6 @@ services:
       - ENABLE_ES=true
       - ES_SEEDS=elasticsearch
       - ES_VERSION=v7
-      - BIND_ON_IP=0.0.0.0
-      - DYNAMIC_CONFIG_FILE_PATH=/etc/temporal/config/dynamicconfig/docker.yaml
     volumes:
       - ./dynamicconfig:/etc/temporal/config/dynamicconfig
     ports:


### PR DESCRIPTION

## What was changed
Switched from the autosetup image to the server and admin-tools images. 

## Why?
autosetup is deprecated and we are no longer building new images when there's commits to the server repo
