### PR TITLE
Update issue template to include Rust SDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -23,10 +23,10 @@ assignees: ''
 
 - [ ] Go - 
 - [ ] Java - 
-- [ ] Core - 
 - [ ] TypeScript - 
 - [ ] Python - 
 - [ ] .NET - 
 - [ ] Ruby - 
+- [ ] Rust - 
 - [ ] PHP - 
 - [ ] Temporal CLI - 


### PR DESCRIPTION
## What was changed

Add `Rust` to features template, replacing `Core` (it is implied to mean Rust SDK + Core). In the rare case that Core work is divorced from Rust SDK work, issues can be split by issue creators.