### PR TITLE
Don't pass AllowNoPollers=true when unsetting current and ramping version

### DIFF
--- a/features/deployment_versioning/aa_clean_old_deployments/feature.go
+++ b/features/deployment_versioning/aa_clean_old_deployments/feature.go
@@ -23,7 +23,10 @@ var Feature = harness.Feature{
 		return run, nil
 	},
 	StartWorkflowOptionsMutator: func(o *client.StartWorkflowOptions) {
-		o.WorkflowExecutionTimeout = 0
+		// I observed this complete in 2 minutes 55 seconds when there were many Deployments
+		// to delete. If the deletions are happening frequently, this will likely be shorter.
+		// Giving a long timeout here to make sure it doesn't cause flakiness.
+		o.WorkflowExecutionTimeout = 5 * time.Minute
 	},
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Don't pass AllowNoPollers=true when unsetting current and ramping version.
And remove unnecessary code that used deprecated version string field.

## Why?
Setting AllowNoPollers=true causes the Deployment Client to call `update-with-start` instead of just `update`. In that code path, we verify that Build ID is not empty, because setting a version as current with no pollers creates a new version.

This requires a bug fix in the server, but I don't think it needs to be a patch because it's unlikely people will hit this I think?

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
CI

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
