### PR TITLE
activity/shutdown: Increase timeout for ScheduleToClose for succeeding workflow

### DIFF
--- a/features/activity/shutdown/feature.cs
+++ b/features/activity/shutdown/feature.cs
@@ -45,7 +45,7 @@ class Feature : IFeature
             };
             var ignoreOptions = new ActivityOptions
             {
-                ScheduleToCloseTimeout = TimeSpan.FromSeconds(2),
+                ScheduleToCloseTimeout = TimeSpan.FromMilliseconds(300),
                 RetryPolicy = new() { MaximumAttempts = 1 },
             };
 

--- a/features/activity/shutdown/feature.go
+++ b/features/activity/shutdown/feature.go
@@ -54,7 +54,7 @@ func Workflow(ctx workflow.Context) (string, error) {
 		},
 	})
 	ignoreCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ScheduleToCloseTimeout: 2 * time.Second,
+		ScheduleToCloseTimeout: 300 * time.Millisecond,
 		RetryPolicy: &temporal.RetryPolicy{
 			MaximumAttempts: 1,
 		},

--- a/features/activity/shutdown/feature.java
+++ b/features/activity/shutdown/feature.java
@@ -53,7 +53,7 @@ public interface feature extends Feature {
               feature.class,
               builder ->
                   builder
-                      .setScheduleToCloseTimeout(Duration.ofSeconds(2))
+                      .setScheduleToCloseTimeout(Duration.ofMillis(300))
                       .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build()));
 
       gracefulActivities.cancelSuccess();

--- a/features/activity/shutdown/feature.py
+++ b/features/activity/shutdown/feature.py
@@ -30,7 +30,7 @@ class Workflow:
         )
         handle2 = workflow.start_activity(
             cancel_ignore,
-            schedule_to_close_timeout=timedelta(seconds=2),
+            schedule_to_close_timeout=timedelta(milliseconds=300),
             retry_policy=RetryPolicy(maximum_attempts=1),
         )
 

--- a/features/activity/shutdown/feature.ts
+++ b/features/activity/shutdown/feature.ts
@@ -38,7 +38,7 @@ const gracefulActivities = wf.proxyActivities<typeof activitiesImpl>({
 });
 
 const ignoringActivities = wf.proxyActivities<typeof activitiesImpl>({
-  scheduleToCloseTimeout: '2s',
+  scheduleToCloseTimeout: '300ms',
   retry: { maximumAttempts: 1 },
 });
 


### PR DESCRIPTION
## What was changed
<!-- Describe what has changed in this PR -->
Create separate timeout `30s` for the successing/failing workflows, while keeping the `ignore` workflow at 300ms. This should not increase the time it takes for tests to finish, but should reduce the raciness, if `cancellSuccess/cancelFailure` couldn't ocmplete within 300ms

Change TS to use setTimeout to not react to cancellation. 

## Why?
<!-- Tell your future self why have you made these changes -->
Reduce test flakes

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
