### PR TITLE
fix(typescript): avoid race in activity shutdown test

### DIFF
--- a/features/activity/shutdown/feature.ts
+++ b/features/activity/shutdown/feature.ts
@@ -46,6 +46,9 @@ export async function workflow(): Promise<string> {
   const fut = gracefulActivities.cancelSuccess();
   const fut1 = gracefulActivities.cancelFailure();
   const fut2 = ignoringActivities.cancelIgnore();
+  // Register rejection handlers eagerly in case harness is slow seeing first activity scheduled event
+  fut1.catch(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
+  fut2.catch(() => {}); // eslint-disable-line @typescript-eslint/no-empty-function
 
   await fut;
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Add empty rejection handlers to activities in activity shutdown test. 

## Why?
Hopefully fix a flake in this test that triggers when the time between starting `cancelIgnore` activity and the first activity scheduled event gets seen by the harness exceeds 300ms. When this happens, `cancelIgnore` can end up triggering an unhandled rejection since execution hasn't yet gotten to `try { await fut2 } catch { ... }`.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI

3. Any docs updates needed?
N/A
