### PR TITLE
Update .NET SDK default version to 1.11.1

### DIFF
--- a/dotnet.csproj
+++ b/dotnet.csproj
@@ -16,7 +16,7 @@
 
   <!-- Default SDK version if not specified in command line -->
   <PropertyGroup Condition="'$(TemporalioVersion)' == '' And '$(TemporalioProjectReference)' == ''">
-    <TemporalioVersion>1.6.0</TemporalioVersion>
+    <TemporalioVersion>1.11.1</TemporalioVersion>
   </PropertyGroup>
 
   <Target Name="CheckCommandLineProperties">


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

Update the .NET SDK default version to 1.11.1

## Why?

Default to latest .NET SDK version at this time.

## Checklist
1. How was this tested: Existing tests
2. Any docs updates needed? No