### PR TITLE
Fix `activity/cancel_try_cancel/feature.ts` after breaking change in Activity Info

### DIFF
--- a/features/activity/cancel_try_cancel/feature.ts
+++ b/features/activity/cancel_try_cancel/feature.ts
@@ -68,7 +68,7 @@ const activitiesImpl = {
 
     // Send to signal
     await client.workflow
-      .getHandle(Context.current().info.workflowExecution.workflowId)
+      .getHandle(Context.current().info.workflowExecution!.workflowId)
       .signal(activityResultSignal, result);
   },
 };


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
TS SDK PR https://github.com/temporalio/sdk-typescript/pull/2029 introduced a breaking change to Activity Info where `workflowExecution` is now an optional field, meaning it requires `?` or `!` to access. This PR adapts the sample code to this change.