### PR TITLE
sdkbuild: pass --ignore-scripts to harness pnpm install

### DIFF
--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -217,6 +217,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
 		return nil, fmt.Errorf("failed writing tsconfig.json: %w", err)
 	}
 
+	// Install
 	cmd := exec.CommandContext(ctx, "corepack", "pnpm", "install", "--ignore-scripts")
 	cmd.Dir = dir
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -152,7 +152,11 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
   "pnpm": {
 		"overrides": {
 			"protobufjs": "7.5.1"
-		}
+		},
+		"onlyBuiltDependencies": [
+			"@swc/core",
+			"protobufjs"
+		]
   }
 }`
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(packageJSON), 0644); err != nil {

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -152,11 +152,7 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
   "pnpm": {
 		"overrides": {
 			"protobufjs": "7.5.1"
-		},
-		"onlyBuiltDependencies": [
-			"@swc/core",
-			"protobufjs"
-		]
+		}
   }
 }`
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(packageJSON), 0644); err != nil {
@@ -221,8 +217,11 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
 		return nil, fmt.Errorf("failed writing tsconfig.json: %w", err)
 	}
 
-	// Install
-	cmd := exec.CommandContext(ctx, "corepack", "pnpm", "install")
+	// Install — `--ignore-scripts` mirrors the SDK install above and avoids
+	// pnpm 10's strict-builds rejection (`ERR_PNPM_IGNORED_BUILDS`) when
+	// transitive deps such as @swc/core or protobufjs ship postinstall
+	// scripts. The harness only needs the deps on disk for tsc/runtime.
+	cmd := exec.CommandContext(ctx, "corepack", "pnpm", "install", "--ignore-scripts")
 	cmd.Dir = dir
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 	if options.ApplyToCommand != nil {

--- a/sdkbuild/typescript.go
+++ b/sdkbuild/typescript.go
@@ -217,10 +217,6 @@ func BuildTypeScriptProgram(ctx context.Context, options BuildTypeScriptProgramO
 		return nil, fmt.Errorf("failed writing tsconfig.json: %w", err)
 	}
 
-	// Install — `--ignore-scripts` mirrors the SDK install above and avoids
-	// pnpm 10's strict-builds rejection (`ERR_PNPM_IGNORED_BUILDS`) when
-	// transitive deps such as @swc/core or protobufjs ship postinstall
-	// scripts. The harness only needs the deps on disk for tsc/runtime.
 	cmd := exec.CommandContext(ctx, "corepack", "pnpm", "install", "--ignore-scripts")
 	cmd.Dir = dir
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr


### PR DESCRIPTION
## Summary

- Feature tests are failing on [main](https://github.com/temporalio/features/actions/runs/25167315957/job/74890559425) and on [sdk-typescript main](https://github.com/temporalio/sdk-typescript/actions/runs/25228580503/job/74888488064) after the release of protobuf@7.5.6 last week, with the same error:
  ```
  [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @swc/core@1.15.33, protobufjs@7.5.5, protobufjs@7.5.6
  ```
- The SDK install just above this code already passes `--ignore-scripts` for the same reason. This change mirrors that for the harness install.
- The `pnpm.overrides`/`pnpm.onlyBuiltDependencies` route does not help — the rejection is a strict-build policy, not a version mismatch (verified empirically: even with `onlyBuiltDependencies: ["@swc/core", "protobufjs"]` set in the generated package.json, pnpm 10.33.4 in CI still raises `ERR_PNPM_IGNORED_BUILDS`).

## Test plan

- [x] feature-tests-ts CI passes on this commit (currently broken on main).