### PR TITLE
fix: scrub principal from history before diff

### DIFF
--- a/harness/go/history/history.go
+++ b/harness/go/history/history.go
@@ -170,6 +170,7 @@ func scrubRunSpecificScalars(v interface{}) {
 		v.Version = 0 // This field is used for global namespaces and replication conflict resolution, ignore it
 		v.EventTime = nil
 		v.TaskId = 0
+		v.Principal = nil
 	case *history.WorkflowExecutionStartedEventAttributes:
 		v.OriginalExecutionRunId = ""
 		v.Identity = ""


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Do not include newly added `principal` field when diffing histories.

## Why?
This is a run specific field and can/will be different with compatible histories.

## Checklist
<!--- add/delete as needed --->

1. Closes N/A

2. How was this tested:
CI should now pass

3. Any docs updates needed?
N/A
