### PR TITLE
Simplify README by removing specific prereq versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ go build -o temporal-features # or temporal-features.exe on Windows
 
 Prerequisites:
 
-- [Go](https://golang.org/) 1.17+
-- [JDK](https://adoptium.net/?variant=openjdk11&jvmVariant=hotspot) 11+
-- [Node](https://nodejs.org) 16+
+Install versions of these runtimes and package managers that are compatible with the checked-in project files
+and lockfiles:
+
+- [Go](https://golang.org/)
+- [JDK](https://adoptium.net/)
+- [Node](https://nodejs.org)
 - [uv](https://docs.astral.sh/uv/)
-- [.NET](https://dotnet.microsoft.com) 7+
-- [PHP](https://www.php.net/) 8.1+
-  - [Composer](https://getcomposer.org/)
-- [Ruby](https://www.ruby-lang.org/) 4.0+
+- [.NET](https://dotnet.microsoft.com)
+- [PHP](https://www.php.net/) / [Composer](https://getcomposer.org/)
+- [Ruby](https://www.ruby-lang.org/)
 
 Command:
 


### PR DESCRIPTION
## What was changed
Removed versions for dependencies like Go, JDK, Node, etc. Made a more general statement to check the project files and lock files.

## Why?
These are outdated and are not accurately maintained. Better to be more vague than to have wrong/outdated information

## Checklist

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
