### PR TITLE
Ruby: Use default version when none specified

### DIFF
--- a/sdkbuild/ruby.go
+++ b/sdkbuild/ruby.go
@@ -108,6 +108,8 @@ func BuildRubyProgram(ctx context.Context, options BuildRubyProgramOptions) (*Ru
 	} else if options.Version != "" {
 		version := strings.TrimPrefix(options.Version, "v")
 		gemfileLines = append(gemfileLines, fmt.Sprintf(`gem "temporalio", %q`, version))
+	} else {
+		gemfileLines = append(gemfileLines, `gem "temporalio"`)
 	}
 
 	moreDependencyLines, err := renderRubyDependencies(options.MoreDependencies)


### PR DESCRIPTION
## What was changed

If no version is passed in, allow package manager to default to latest

## Why?
<!-- Tell your future self why have you made these changes -->
More intuitive?

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
