### PR TITLE
Skip Nexus Tests on Cloud

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,11 +25,10 @@ import (
 	"github.com/urfave/cli/v2"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/testsuite"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 )
 
@@ -676,16 +675,14 @@ func (r *Runner) createNexusEndpoints(ctx context.Context, run *cmd.Run) (func()
 		})
 		cancel()
 		if err != nil {
-			// Only skip when the server signals that Nexus endpoint management is unavailable
-			// (e.g. Temporal Cloud returns Unauthenticated/PermissionDenied/Unimplemented).
-			// Other errors are real failures and must be surfaced.
-			code := status.Code(err)
-			if code != codes.Unauthenticated && code != codes.PermissionDenied && code != codes.Unimplemented {
+			// Only skip when the server signals that Nexus endpoint management is unavailable.
+			var permDenied *serviceerror.PermissionDenied
+			if !errors.As(err, &permDenied) {
 				cleanup()
 				return noop, fmt.Errorf("failed creating nexus endpoint for %v: %w", feature.Dir, err)
 			}
 			r.log.Warn("Skipping Nexus features: server does not support Nexus endpoint creation",
-				"Feature", feature.Dir, "Code", code, "Error", err)
+				"Feature", feature.Dir, "Error", err)
 			cleanup()
 			kept := run.Features[:0]
 			for _, f := range run.Features {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -282,6 +282,10 @@ func (r *Runner) Run(ctx context.Context, patterns []string) error {
 		return err
 	}
 	defer deleteEndpoints()
+	if len(run.Features) == 0 {
+		r.log.Info("No features left to run after Nexus skip; treating run as successful")
+		return nil
+	}
 
 	// Ensure any created temp dir is cleaned on ctrl-c or normal exit
 	if r.config.DirName == "" && !r.config.RetainTempDir {
@@ -673,10 +677,10 @@ func (r *Runner) createNexusEndpoints(ctx context.Context, run *cmd.Run) (func()
 		cancel()
 		if err != nil {
 			// Only skip when the server signals that Nexus endpoint management is unavailable
-			// (e.g. Temporal Cloud returns PermissionDenied/Unimplemented). Other errors are
-			// real failures and must surface.
+			// (e.g. Temporal Cloud returns Unauthenticated/PermissionDenied/Unimplemented).
+			// Other errors are real failures and must be surfaced.
 			code := status.Code(err)
-			if code != codes.PermissionDenied && code != codes.Unimplemented {
+			if code != codes.Unauthenticated && code != codes.PermissionDenied && code != codes.Unimplemented {
 				cleanup()
 				return noop, fmt.Errorf("failed creating nexus endpoint for %v: %w", feature.Dir, err)
 			}
@@ -690,9 +694,6 @@ func (r *Runner) createNexusEndpoints(ctx context.Context, run *cmd.Run) (func()
 				}
 			}
 			run.Features = kept
-			if len(run.Features) == 0 {
-				return noop, fmt.Errorf("all features skipped: server does not support Nexus endpoint creation")
-			}
 			return noop, nil
 		}
 		feature.NexusEndpoint = name

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,6 +28,8 @@ import (
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/testsuite"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 )
 
@@ -670,8 +672,28 @@ func (r *Runner) createNexusEndpoints(ctx context.Context, run *cmd.Run) (func()
 		})
 		cancel()
 		if err != nil {
+			// Only skip when the server signals that Nexus endpoint management is unavailable
+			// (e.g. Temporal Cloud returns PermissionDenied/Unimplemented). Other errors are
+			// real failures and must surface.
+			code := status.Code(err)
+			if code != codes.PermissionDenied && code != codes.Unimplemented {
+				cleanup()
+				return noop, fmt.Errorf("failed creating nexus endpoint for %v: %w", feature.Dir, err)
+			}
+			r.log.Warn("Skipping Nexus features: server does not support Nexus endpoint creation",
+				"Feature", feature.Dir, "Code", code, "Error", err)
 			cleanup()
-			return noop, fmt.Errorf("failed creating nexus endpoint for %v: %w", feature.Dir, err)
+			kept := run.Features[:0]
+			for _, f := range run.Features {
+				if !strings.HasPrefix(f.Dir, nexusFeatureDirPrefix) {
+					kept = append(kept, f)
+				}
+			}
+			run.Features = kept
+			if len(run.Features) == 0 {
+				return noop, fmt.Errorf("all features skipped: server does not support Nexus endpoint creation")
+			}
+			return noop, nil
 		}
 		feature.NexusEndpoint = name
 		created = append(created, createdEndpoint{ID: res.Endpoint.Id, Version: res.Endpoint.Version, Name: name})


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
If the feature tests runner detect the server doesn't support creating a Nexus endpoint skip the Nexus tests

## Why?
So we can skip Nexus tests on Cloud without failing the test run

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
