### PR TITLE
Route workflow inputs through env vars in run steps

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -53,7 +53,9 @@ jobs:
         with:
           go-version: '^1.21'
       - name: Lint dockerfile
-        run: docker run --rm -i hadolint/hadolint < dockerfiles/${{inputs.lang}}.Dockerfile
+        env:
+          INPUT_LANG: ${{ inputs.lang }}
+        run: docker run --rm -i hadolint/hadolint < "dockerfiles/$INPUT_LANG.Dockerfile"
 
       # Download the certs to be mounted as a volume in the running container
       - name: Download certs to temporary directory
@@ -70,15 +72,28 @@ jobs:
       - name: Build docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_LANG: ${{ inputs.lang }}
+          INPUT_SDK_REPO_REF: ${{ inputs.sdk-repo-ref }}
+          INPUT_SDK_REPO_URL: ${{ inputs.sdk-repo-url }}
+          INPUT_SDK_VERSION: ${{ inputs.sdk-version }}
+          INPUT_SEMVER_LATEST: ${{ inputs.semver-latest }}
         run: |
-          go run . build-image --lang ${{ inputs.lang }} \
-          ${{ inputs.sdk-repo-ref && format('--repo-ref {0}', inputs.sdk-repo-ref) || '' }} \
-          ${{ inputs.sdk-repo-ref && inputs.sdk-repo-url && format('--repo-url {0}', inputs.sdk-repo-url) || '' }} \
-          ${{ !inputs.sdk-repo-ref && format('--version {0}', inputs.sdk-version) || '' }} \
-          ${{ inputs.semver-latest != 'none' && format('--semver-latest {0}', inputs.semver-latest) || '' }}
+          args=(--lang "$INPUT_LANG")
+          if [ -n "$INPUT_SDK_REPO_REF" ]; then
+            args+=(--repo-ref "$INPUT_SDK_REPO_REF")
+            if [ -n "$INPUT_SDK_REPO_URL" ]; then
+              args+=(--repo-url "$INPUT_SDK_REPO_URL")
+            fi
+          else
+            args+=(--version "$INPUT_SDK_VERSION")
+          fi
+          if [ "$INPUT_SEMVER_LATEST" != "none" ]; then
+            args+=(--semver-latest "$INPUT_SEMVER_LATEST")
+          fi
+          go run . build-image "${args[@]}"
 
       - name: Test with Dev Server
-        run: docker run --rm -i -v /tmp/temporal-certs:/certs ${{ env.FEATURES_BUILT_IMAGE_TAG }}
+        run: docker run --rm -i -v /tmp/temporal-certs:/certs "$FEATURES_BUILT_IMAGE_TAG"
 
       - name: Test with Cloud
         # Only supported in non-fork runs
@@ -91,7 +106,7 @@ jobs:
             docker run --rm -i \
             -v /tmp/temporal-certs:/certs \
             --env TEMPORAL_FEATURES_DISABLE_WORKFLOW_COMPLETION_CHECK=true \
-            ${{ env.FEATURES_BUILT_IMAGE_TAG }} \
+            "$FEATURES_BUILT_IMAGE_TAG" \
             --server $TEMPORAL_CLOUD_ADDRESS \
             --namespace $TEMPORAL_CLOUD_NAMESPACE \
             --client-cert-path /certs/client.pem \

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -142,7 +142,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang cs ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-dotnet)' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang cs --version "$(realpath ../sdk-dotnet)"
+          else
+            go run . run --lang cs --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -39,8 +39,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", ts version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", dotnet sdk version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -138,7 +140,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang cs ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-dotnet)' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang cs ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-dotnet)' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -39,8 +39,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", go sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", go sdk version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -114,7 +116,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang go ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-go)' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang go ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-go)' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -118,7 +118,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang go ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-go)' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang go --version "$(realpath ../sdk-go)"
+          else
+            go run . run --lang go --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -40,8 +40,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", java sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", java sdk version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -120,7 +122,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang java ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-java)' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang java ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-java)' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -124,7 +124,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang java ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-java)' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang java --version "$(realpath ../sdk-java)"
+          else
+            go run . run --lang java --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -105,7 +105,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang php ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang php --version ""
+          else
+            go run . run --lang php --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -37,8 +37,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", PHP sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", PHP sdk version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -101,7 +103,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang php ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang php ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -144,7 +144,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang python ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-python)' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang python --version "$(realpath ../sdk-python)"
+          else
+            go run . run --lang python --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -39,8 +39,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", python sdk version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", python sdk version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -140,7 +142,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang python ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-python)' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang python ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-python)' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -154,7 +154,13 @@ jobs:
         if: inputs.docker-image-artifact-name == ''
         env:
           INPUT_VERSION: ${{ inputs.version }}
-        run: go run . run --lang ts ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-ts)' || '$INPUT_VERSION' }}"
+          INPUT_VERSION_IS_REPO_REF: ${{ inputs.version-is-repo-ref }}
+        run: |
+          if [ "$INPUT_VERSION_IS_REPO_REF" = "true" ]; then
+            go run . run --lang ts --version "$(realpath ../sdk-ts)"
+          else
+            go run . run --lang ts --version "$INPUT_VERSION"
+          fi
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -39,8 +39,10 @@ jobs:
         working-directory: ./features
     steps:
       - name: Print git info
-        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", ts version: ${{ inputs.version }}'
+        run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", ts version: "$INPUT_VERSION"'
         working-directory: '.'
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: Download docker artifacts
         if: ${{ inputs.docker-image-artifact-name }}
@@ -150,7 +152,9 @@ jobs:
 
       - name: Run SDK-features tests directly
         if: inputs.docker-image-artifact-name == ''
-        run: go run . run --lang ts ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-ts)' || inputs.version }}"
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: go run . run --lang ts ${{ inputs.docker-image-artifact-name && '--server localhost:7233 --namespace default' || ''}} --version "${{ inputs.version-is-repo-ref && '$(realpath ../sdk-ts)' || '$INPUT_VERSION' }}"
 
       # Running the tests in their own step keeps the logs readable
       - name: Run containerized SDK-features tests


### PR DESCRIPTION
This PR changes how we pass dynamic inputs into shell `run:` blocks via step-level `env:` variables referenced as quoted shell variables, instead of interpolating `${{ ... }}` expressions directly into command strings. This matches the existing `ruby.yaml` convention and keeps input handling consistent across all reusable workflows. Should have no behavioral change.

- go/python/java/typescript/dotnet/php: the `"Print git info"` and `"Run SDK-features tests directly"` steps now read the version from `$INPUT_VERSION`.
- `docker-images.yaml`: lang/sdk-repo-ref/sdk-repo-url/sdk-version/ semver-latest are passed as `INPUT_*` env vars and assembled into a quoted bash args array; `FEATURES_BUILT_IMAGE_TAG` is referenced as a shell variable.
- Fix a stale label in `dotnet.yaml`'s `"Print git info"` step (`"ts version"` -> `"dotnet sdk version"`).
