### PR TITLE
VLN-1598: remediate checkout-below-v7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '^1.21'
@@ -134,7 +134,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
 
       - run: npm ci
@@ -155,7 +155,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.10'
@@ -175,7 +175,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup PHP 8.2
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
       - run: dotnet build
       - run: dotnet test
@@ -225,7 +225,7 @@ jobs:
     steps:
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF", os: ${{ matrix.os }}'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup Ruby
         uses: ruby/setup-ruby@ba696adf55506673e48342a66e30f1f53cadeae0 # v1
         with:

--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -48,7 +48,7 @@ jobs:
         run: exit 1
       - name: Print build information
         run: 'echo head_ref: "$GITHUB_HEAD_REF", ref: "$GITHUB_REF"'
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: '^1.21'

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -70,7 +70,7 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkout .NET SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.dotnet-repo-path }}
           submodules: recursive

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,7 +70,7 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Checkout Go SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.go-repo-path }}
           submodules: recursive

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -71,14 +71,14 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
           fetch-depth: 0
       - name: Checkout Java SDK repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ inputs.version-is-repo-ref }}
         with:
           repository: ${{ inputs.java-repo-path }}

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -68,7 +68,7 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -70,14 +70,14 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
       - name: Checkout Python SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.python-repo-path }}
           submodules: recursive

--- a/.github/workflows/ruby.yaml
+++ b/.github/workflows/ruby.yaml
@@ -65,7 +65,7 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}

--- a/.github/workflows/typescript.yaml
+++ b/.github/workflows/typescript.yaml
@@ -70,14 +70,14 @@ jobs:
         working-directory: '.'
 
       - name: Checkout SDK features repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: features
           repository: ${{ inputs.features-repo-path }}
           ref: ${{ inputs.features-repo-ref }}
       - name: Checkout typescript SDK repo
         if: ${{ inputs.version-is-repo-ref }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.typescript-repo-path }}
           submodules: recursive


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>checkout-below-v7</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/features</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1598">VLN-1598</a></td></tr>
</table>

## Summary

- `.github/workflows/ci.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.
- `.github/workflows/docker-images.yaml`: Updated the `actions/checkout` use to the required v7.0.0 commit pin.
- `.github/workflows/dotnet.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.
- `.github/workflows/go.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.
- `.github/workflows/java.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.
- `.github/workflows/php.yaml`: Updated the `actions/checkout` use to the required v7.0.0 commit pin.
- `.github/workflows/python.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.
- `.github/workflows/ruby.yaml`: Updated the `actions/checkout` use to the required v7.0.0 commit pin.
- `.github/workflows/typescript.yaml`: Updated all `actions/checkout` uses to the required v7.0.0 commit pin.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — regenerate the fix from scratch against the current base