### PR TITLE
ci(dotnet): fix rust-cache path and preinstall the pinned toolchain

### DIFF
--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -101,11 +101,18 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
+      # The step above installs stable; the bridge pins its own channel. Install that one
+      # up front so the parallel cargo runs in `dotnet build` don't race to install it.
+      - name: Install the bridge's pinned Rust toolchain
+        if: ${{ inputs.version-is-repo-ref }}
+        run: rustup toolchain install
+        working-directory: ./sdk-dotnet/src/Temporalio/Bridge/sdk-core
+
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: ${{ inputs.version-is-repo-ref }}
         with:
           cache-bin: false
-          workspaces: sdk-dotnet/src/Temporalio/Bridge
+          workspaces: sdk-dotnet/src/Temporalio/Bridge/sdk-core
 
       # Build .NET SDK if using repo
       # Don't build during install phase since we're going to explicitly build


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed

For .NET builds:
- Install pinned Rust toolchain before invoking `dotnet build`.
- Set correct Rust cache path to avoid rebuilds of same source.

## Why?

Fix the invalid cache path and preinstall toolchain before parallel dotnet builds attempt to do so.

## Checklist
<!--- add/delete as needed --->

1. How was this tested: Temporary PR run: https://github.com/temporalio/sdk-dotnet/actions/runs/32896796033/job/97961235498?pr=836

1. Any docs updates needed? No
